### PR TITLE
Pandas.Series future

### DIFF
--- a/src/pyg4ometry/convert/fluka2g4materials.py
+++ b/src/pyg4ometry/convert/fluka2g4materials.py
@@ -255,7 +255,7 @@ class _PeriodicTable:
     def atomicMassFromZ(self, z):
         t = self.table
         mask = t["AtomicNumber"] == z
-        return float(t["AtomicMass"][mask])
+        return float(t["AtomicMass"][mask].iloc[0])
 
     def atomicNumberAndMassFromSymbol(self, symbol):
         t = self.table

--- a/src/pyg4ometry/convert/fluka2g4materials.py
+++ b/src/pyg4ometry/convert/fluka2g4materials.py
@@ -260,7 +260,7 @@ class _PeriodicTable:
     def atomicNumberAndMassFromSymbol(self, symbol):
         t = self.table
         mask = t["Symbol"] == symbol
-        massNumber = int(t.AtomicMass[mask])
-        atomicNumber = int(t.AtomicNumber[mask])
+        massNumber = int(t.AtomicMass[mask].iloc[0])
+        atomicNumber = int(t.AtomicNumber[mask].iloc[0])
 
         return atomicNumber, massNumber


### PR DESCRIPTION
int or float of Series, is deprecated need to run 

`int(Series.iloc[0])` opposed to `int(Series)