### PR TITLE
Skip PyPy builds in CI, enable cross-compiling on arm64 on MacOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,9 +143,13 @@ isort.required-imports = ["from __future__ import annotations"]
 "tests/**" = ["T20"]
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "g4edge/pyg4ometry-manylinux2014_x86_64:latest"
 build = ["*macosx*", "*manylinux_x86_64"]
-skip = ["cp36-*"]
+skip = ["pp*", "cp36-*"]
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "g4edge/pyg4ometry-manylinux2014_x86_64:latest"
+archs = ["auto"]
 
 [tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
 before-all = ".github/bin/install-deps-macos.sh"


### PR DESCRIPTION
To decrease CI time, we could also avoid building wheels for old Python versions (like 3.7 or even 3.8).