### PR TITLE
Add comments to all isotopes, elements and materials in the g4->fluka conversion

### DIFF
--- a/src/pyg4ometry/convert/geant42Fluka.py
+++ b/src/pyg4ometry/convert/geant42Fluka.py
@@ -2006,7 +2006,9 @@ def geant4MaterialDict2Fluka(matr, freg):
     return freg
 
 
-def geant4Material2Fluka(material, freg, suggestedDensity=None, elementSuffix=False, materialNameShort=None):
+def geant4Material2Fluka(
+    material, freg, suggestedDensity=None, elementSuffix=False, materialNameShort=None
+):
     materialName = material.name
     materialInstance = material
 
@@ -2034,20 +2036,26 @@ def geant4Material2Fluka(material, freg, suggestedDensity=None, elementSuffix=Fa
 
         elif materialInstance.type == "nist":
             # make material object from dictionary of information
-            nistMatInstance = _geant4.nist_material_2geant4Material(materialInstance.name)
+            nistMatInstance = _geant4.nist_material_2geant4Material(
+                materialInstance.name
+            )
             nistMatInstance.type = "composite"  # prevent recursion - Material internally decides if it's a nist material or not
-            return geant4Material2Fluka(nistMatInstance, freg, materialNameShort=materialNameShort)
+            return geant4Material2Fluka(
+                nistMatInstance, freg, materialNameShort=materialNameShort
+            )
 
         elif materialInstance.type == "arbitrary":
             msg = "Cannot have material with arbitrary type"
             raise Exception(msg)
 
         elif materialInstance.type == "simple":
-            fe = _fluka.Material(materialNameShort,
-                                 materialInstance.atomic_number,
-                                 materialInstance.density,
-                                 flukaregistry=freg,
-                                 comment="material-simple: "+materialName)
+            fe = _fluka.Material(
+                materialNameShort,
+                materialInstance.atomic_number,
+                materialInstance.density,
+                flukaregistry=freg,
+                comment="material-simple: " + materialName,
+            )
             return fe
 
         elif materialInstance.type == "composite":
@@ -2056,11 +2064,13 @@ def geant4Material2Fluka(material, freg, suggestedDensity=None, elementSuffix=Fa
 
             iComp = 0
             for comp in materialInstance.components:
-                fm = geant4Material2Fluka(comp[0],
-                                          freg,
-                                          materialInstance.density,
-                                          elementSuffix=True,
-                                          materialNameShort=materialNameShort + format(iComp, "02"))
+                fm = geant4Material2Fluka(
+                    comp[0],
+                    freg,
+                    materialInstance.density,
+                    elementSuffix=True,
+                    materialNameShort=materialNameShort + format(iComp, "02"),
+                )
 
                 compFraction = float(comp[1])
                 compFractionType = comp[2]
@@ -2073,12 +2083,14 @@ def geant4Material2Fluka(material, freg, suggestedDensity=None, elementSuffix=Fa
                 flukaComposition.append((fm, compFraction))
                 iComp += 1
 
-            mat = _fluka.Compound(materialNameShort,
-                                  materialInstance.density,
-                                  flukaComposition,
-                                  fractionType=flukaFractionType,
-                                  flukaregistry=freg,
-                                  comment="material-composite: "+materialName)
+            mat = _fluka.Compound(
+                materialNameShort,
+                materialInstance.density,
+                flukaComposition,
+                fractionType=flukaFractionType,
+                flukaregistry=freg,
+                comment="material-composite: " + materialName,
+            )
             return mat
 
     elif isinstance(materialInstance, _geant4.Element):
@@ -2092,12 +2104,14 @@ def geant4Material2Fluka(material, freg, suggestedDensity=None, elementSuffix=Fa
         #    return freg.materials[materialNameShort]
 
         if materialInstance.type == "element-simple":
-            mat = _fluka.Material(materialNameShort,
-                                  materialInstance.Z,
-                                  suggestedDensity,
-                                  materialInstance.A,
-                                  flukaregistry=freg,
-                                  comment="element-simple: "+materialName)
+            mat = _fluka.Material(
+                materialNameShort,
+                materialInstance.Z,
+                suggestedDensity,
+                materialInstance.A,
+                flukaregistry=freg,
+                comment="element-simple: " + materialName,
+            )
             return mat
 
         elif materialInstance.type == "element-composite":
@@ -2107,7 +2121,11 @@ def geant4Material2Fluka(material, freg, suggestedDensity=None, elementSuffix=Fa
 
             iComp = 0
             for iso in materialInstance.components:
-                fi = geant4Material2Fluka(iso[0], freg, materialNameShort=materialNameShort + format(iComp, "02"))
+                fi = geant4Material2Fluka(
+                    iso[0],
+                    freg,
+                    materialNameShort=materialNameShort + format(iComp, "02"),
+                )
 
                 compFlukaName = makeShortName(iso[0].name)
                 compFraction = iso[1]
@@ -2117,24 +2135,30 @@ def geant4Material2Fluka(material, freg, suggestedDensity=None, elementSuffix=Fa
                 flukaComponentFractions.append(compFraction)
                 iComp += 1
 
-            flukaComposition = [ (c, f) for c, f in zip(flukaComponents, flukaComponentFractions) ]
+            flukaComposition = [
+                (c, f) for c, f in zip(flukaComponents, flukaComponentFractions)
+            ]
 
-            mat = _fluka.Compound(materialNameShort,
-                                  0.123456789,
-                                  flukaComposition,
-                                  fractionType="atomic",
-                                  flukaregistry=freg,
-                                  comment="element-composite: "+materialName)
+            mat = _fluka.Compound(
+                materialNameShort,
+                0.123456789,
+                flukaComposition,
+                fractionType="atomic",
+                flukaregistry=freg,
+                comment="element-composite: " + materialName,
+            )
             return mat
 
     elif isinstance(materialInstance, _geant4.Isotope):
-        fi = _fluka.Material(materialNameShort,
-                             materialInstance.Z,
-                             10, # this density won't be used finally but needs to be there
-                             flukaregistry=freg,
-                             atomicMass=materialInstance.a,
-                             massNumber=materialInstance.N,
-                             comment="isotope: "+materialName)
+        fi = _fluka.Material(
+            materialNameShort,
+            materialInstance.Z,
+            10,  # this density won't be used finally but needs to be there
+            flukaregistry=freg,
+            atomicMass=materialInstance.a,
+            massNumber=materialInstance.N,
+            comment="isotope: " + materialName,
+        )
         return fi
     else:
         raise TypeError('Unknown material.type "' + str(material.type) + '"')

--- a/src/pyg4ometry/convert/geant42Fluka.py
+++ b/src/pyg4ometry/convert/geant42Fluka.py
@@ -2006,9 +2006,7 @@ def geant4MaterialDict2Fluka(matr, freg):
     return freg
 
 
-def geant4Material2Fluka(
-    material, freg, suggestedDensity=None, elementSuffix=False, materialNameShort=None
-):
+def geant4Material2Fluka(material, freg, suggestedDensity=None, elementSuffix=False, materialNameShort=None):
     materialName = material.name
     materialInstance = material
 
@@ -2036,25 +2034,20 @@ def geant4Material2Fluka(
 
         elif materialInstance.type == "nist":
             # make material object from dictionary of information
-            nistMatInstance = _geant4.nist_material_2geant4Material(
-                materialInstance.name
-            )
+            nistMatInstance = _geant4.nist_material_2geant4Material(materialInstance.name)
             nistMatInstance.type = "composite"  # prevent recursion - Material internally decides if it's a nist material or not
-            return geant4Material2Fluka(
-                nistMatInstance, freg, materialNameShort=materialNameShort
-            )
+            return geant4Material2Fluka(nistMatInstance, freg, materialNameShort=materialNameShort)
 
         elif materialInstance.type == "arbitrary":
             msg = "Cannot have material with arbitrary type"
             raise Exception(msg)
 
         elif materialInstance.type == "simple":
-            fe = _fluka.Material(
-                materialNameShort,
-                materialInstance.atomic_number,
-                materialInstance.density,
-                flukaregistry=freg,
-            )
+            fe = _fluka.Material(materialNameShort,
+                                 materialInstance.atomic_number,
+                                 materialInstance.density,
+                                 flukaregistry=freg,
+                                 comment="material-simple: "+materialName)
             return fe
 
         elif materialInstance.type == "composite":
@@ -2063,13 +2056,11 @@ def geant4Material2Fluka(
 
             iComp = 0
             for comp in materialInstance.components:
-                fm = geant4Material2Fluka(
-                    comp[0],
-                    freg,
-                    materialInstance.density,
-                    elementSuffix=True,
-                    materialNameShort=materialNameShort + format(iComp, "02"),
-                )
+                fm = geant4Material2Fluka(comp[0],
+                                          freg,
+                                          materialInstance.density,
+                                          elementSuffix=True,
+                                          materialNameShort=materialNameShort + format(iComp, "02"))
 
                 compFraction = float(comp[1])
                 compFractionType = comp[2]
@@ -2082,13 +2073,12 @@ def geant4Material2Fluka(
                 flukaComposition.append((fm, compFraction))
                 iComp += 1
 
-            mat = _fluka.Compound(
-                materialNameShort,
-                materialInstance.density,
-                flukaComposition,
-                fractionType=flukaFractionType,
-                flukaregistry=freg,
-            )
+            mat = _fluka.Compound(materialNameShort,
+                                  materialInstance.density,
+                                  flukaComposition,
+                                  fractionType=flukaFractionType,
+                                  flukaregistry=freg,
+                                  comment="material-composite: "+materialName)
             return mat
 
     elif isinstance(materialInstance, _geant4.Element):
@@ -2102,13 +2092,12 @@ def geant4Material2Fluka(
         #    return freg.materials[materialNameShort]
 
         if materialInstance.type == "element-simple":
-            mat = _fluka.Material(
-                materialNameShort,
-                materialInstance.Z,
-                suggestedDensity,
-                materialInstance.A,
-                flukaregistry=freg,
-            )
+            mat = _fluka.Material(materialNameShort,
+                                  materialInstance.Z,
+                                  suggestedDensity,
+                                  materialInstance.A,
+                                  flukaregistry=freg,
+                                  comment="element-simple: "+materialName)
             return mat
 
         elif materialInstance.type == "element-composite":
@@ -2118,11 +2107,7 @@ def geant4Material2Fluka(
 
             iComp = 0
             for iso in materialInstance.components:
-                fi = geant4Material2Fluka(
-                    iso[0],
-                    freg,
-                    materialNameShort=materialNameShort + format(iComp, "02"),
-                )
+                fi = geant4Material2Fluka(iso[0], freg, materialNameShort=materialNameShort + format(iComp, "02"))
 
                 compFlukaName = makeShortName(iso[0].name)
                 compFraction = iso[1]
@@ -2132,28 +2117,24 @@ def geant4Material2Fluka(
                 flukaComponentFractions.append(compFraction)
                 iComp += 1
 
-            flukaComposition = [
-                (c, f) for c, f in zip(flukaComponents, flukaComponentFractions)
-            ]
+            flukaComposition = [ (c, f) for c, f in zip(flukaComponents, flukaComponentFractions) ]
 
-            mat = _fluka.Compound(
-                materialNameShort,
-                0.123456789,
-                flukaComposition,
-                fractionType="atomic",
-                flukaregistry=freg,
-            )
+            mat = _fluka.Compound(materialNameShort,
+                                  0.123456789,
+                                  flukaComposition,
+                                  fractionType="atomic",
+                                  flukaregistry=freg,
+                                  comment="element-composite: "+materialName)
             return mat
 
     elif isinstance(materialInstance, _geant4.Isotope):
-        fi = _fluka.Material(
-            materialNameShort,
-            materialInstance.Z,
-            10,
-            flukaregistry=freg,
-            atomicMass=materialInstance.a,
-            massNumber=materialInstance.N,
-        )
+        fi = _fluka.Material(materialNameShort,
+                             materialInstance.Z,
+                             10, # this density won't be used finally but needs to be there
+                             flukaregistry=freg,
+                             atomicMass=materialInstance.a,
+                             massNumber=materialInstance.N,
+                             comment="isotope: "+materialName)
         return fi
     else:
         raise TypeError('Unknown material.type "' + str(material.type) + '"')

--- a/src/pyg4ometry/fluka/card.py
+++ b/src/pyg4ometry/fluka/card.py
@@ -8,7 +8,18 @@ class Card:
     instances from a of FLUKA input, use the fromFree or fromFixed
     class method for FREE and FIXED format, respectively.
     """
-    def __init__(self, keyword, what1=None, what2=None, what3=None, what4=None, what5=None, what6=None, sdum=None):
+
+    def __init__(
+        self,
+        keyword,
+        what1=None,
+        what2=None,
+        what3=None,
+        what4=None,
+        what5=None,
+        what6=None,
+        sdum=None,
+    ):
         self.keyword = keyword
         self.what1 = _attempt_float_coercion(what1)
         self.what2 = _attempt_float_coercion(what2)

--- a/src/pyg4ometry/fluka/card.py
+++ b/src/pyg4ometry/fluka/card.py
@@ -3,23 +3,12 @@ import re
 
 
 class Card:
-    """Card class for representing a FLUKA input card. To construct
+    """
+    Card class for representing a FLUKA input card. To construct
     instances from a of FLUKA input, use the fromFree or fromFixed
     class method for FREE and FIXED format, respectively.
-
     """
-
-    def __init__(
-        self,
-        keyword,
-        what1=None,
-        what2=None,
-        what3=None,
-        what4=None,
-        what5=None,
-        what6=None,
-        sdum=None,
-    ):
+    def __init__(self, keyword, what1=None, what2=None, what3=None, what4=None, what5=None, what6=None, sdum=None):
         self.keyword = keyword
         self.what1 = _attempt_float_coercion(what1)
         self.what2 = _attempt_float_coercion(what2)

--- a/src/pyg4ometry/fluka/material.py
+++ b/src/pyg4ometry/fluka/material.py
@@ -126,15 +126,17 @@ class Material(_MatProp):
 
     """
 
-    def __init__(self,
-                 name,
-                 atomicNumber,
-                 density,
-                 massNumber=None,
-                 atomicMass=None,
-                 pressure=None,
-                 flukaregistry=None,
-                 comment=""):
+    def __init__(
+        self,
+        name,
+        atomicNumber,
+        density,
+        massNumber=None,
+        atomicMass=None,
+        pressure=None,
+        flukaregistry=None,
+        comment="",
+    ):
         self.name = name
         self.atomicNumber = atomicNumber
         self.density = density
@@ -146,12 +148,16 @@ class Material(_MatProp):
             flukaregistry.addMaterial(self)
 
     def toCards(self):
-        material = [_Card("MATERIAL",
-                          what1=self.atomicNumber,
-                          what2=self.atomicMass,
-                          what3=self.density,
-                          what6=self.massNumber,
-                          sdum=self.name)]
+        material = [
+            _Card(
+                "MATERIAL",
+                what1=self.atomicNumber,
+                what2=self.atomicMass,
+                what3=self.density,
+                what6=self.massNumber,
+                sdum=self.name,
+            )
+        ]
         if self.pressure:
             material.append(self.makeMatPropCard())
         return material
@@ -172,7 +178,13 @@ class Material(_MatProp):
 
     @classmethod
     def fromCard(cls, card, flukaregistry):
-        return cls(card.sdum, card.what1, card.what3, massNumber=card.what6, flukaregistry=flukaregistry)
+        return cls(
+            card.sdum,
+            card.what1,
+            card.what3,
+            massNumber=card.what6,
+            flukaregistry=flukaregistry,
+        )
 
 
 class Compound(_MatProp):
@@ -197,7 +209,16 @@ class Compound(_MatProp):
     :type flukaregistry: FlukaRegistry
     """
 
-    def __init__(self, name, density, fractions, fractionType, pressure=None, flukaregistry=None, comment=""):
+    def __init__(
+        self,
+        name,
+        density,
+        fractions,
+        fractionType,
+        pressure=None,
+        flukaregistry=None,
+        comment="",
+    ):
         self.name = name
         self.density = density
         self.fractions = fractions
@@ -278,7 +299,9 @@ class Compound(_MatProp):
         # Map the material names to material/compound instances via the FlukaRegistry.
         fractions = [(flukareg.getMaterial(name), f) for name, f in fractions]
 
-        return cls(compoundName, density, fractions, fractionTypes[0], flukaregistry=flukareg)
+        return cls(
+            compoundName, density, fractions, fractionTypes[0], flukaregistry=flukareg
+        )
 
     def __repr__(self):
         return "<Compound: {}, density={}*g/cm3, nparts={}>".format(

--- a/src/pyg4ometry/geant4/_Material.py
+++ b/src/pyg4ometry/geant4/_Material.py
@@ -375,9 +375,11 @@ class Material(MaterialBase):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(kwargs.get("name", None),
-                         state=kwargs.get("state", None),
-                         registry=kwargs.get("registry", None))
+        super().__init__(
+            kwargs.get("name", None),
+            state=kwargs.get("state", None),
+            registry=kwargs.get("registry", None),
+        )
 
         self.density = kwargs.get("density", None)
         self.atomic_number = kwargs.get("atomic_number", None)
@@ -404,7 +406,11 @@ class Material(MaterialBase):
         elif self.density:
             if self.number_of_components and not self.atomic_number:
                 self.type = "composite"
-            elif (self.atomic_number and self.atomic_weight and not self.number_of_components):
+            elif (
+                self.atomic_number
+                and self.atomic_weight
+                and not self.number_of_components
+            ):
                 self.type = "simple"
             else:
                 msg = f"Material : '{self.name}' Cannot use both atomic number/weight and number_of_components."
@@ -427,12 +433,16 @@ class Material(MaterialBase):
         # After the material type is determined, set the temperature and pressure if provided
         if "temperature" in kwargs:
             temperature = kwargs["temperature"]
-            temperature_unit = kwargs.get("temperature_unit", "K")  # The unit is optional
+            temperature_unit = kwargs.get(
+                "temperature_unit", "K"
+            )  # The unit is optional
             self.set_temperature(temperature, temperature_unit)
 
         if "pressure" in kwargs:
             pressure = kwargs["pressure"]
-            pressure_unit = kwargs.get("pressure_unit", "pascal")  # The unit is optional
+            pressure_unit = kwargs.get(
+                "pressure_unit", "pascal"
+            )  # The unit is optional
             self.set_pressure(pressure, pressure_unit)
 
         self._addToRegistry()
@@ -597,9 +607,11 @@ class Element(MaterialBase):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(kwargs.get("name", None),
-                         state=kwargs.get("state", None),
-                         registry=kwargs.get("registry", None))
+        super().__init__(
+            kwargs.get("name", None),
+            state=kwargs.get("state", None),
+            registry=kwargs.get("registry", None),
+        )
 
         self.symbol = kwargs.get("symbol", None)
         self.n_comp = kwargs.get("n_comp", None)

--- a/src/pyg4ometry/geant4/_Material.py
+++ b/src/pyg4ometry/geant4/_Material.py
@@ -375,11 +375,9 @@ class Material(MaterialBase):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(
-            kwargs.get("name", None),
-            state=kwargs.get("state", None),
-            registry=kwargs.get("registry", None),
-        )
+        super().__init__(kwargs.get("name", None),
+                         state=kwargs.get("state", None),
+                         registry=kwargs.get("registry", None))
 
         self.density = kwargs.get("density", None)
         self.atomic_number = kwargs.get("atomic_number", None)
@@ -406,11 +404,7 @@ class Material(MaterialBase):
         elif self.density:
             if self.number_of_components and not self.atomic_number:
                 self.type = "composite"
-            elif (
-                self.atomic_number
-                and self.atomic_weight
-                and not self.number_of_components
-            ):
+            elif (self.atomic_number and self.atomic_weight and not self.number_of_components):
                 self.type = "simple"
             else:
                 msg = f"Material : '{self.name}' Cannot use both atomic number/weight and number_of_components."
@@ -433,16 +427,12 @@ class Material(MaterialBase):
         # After the material type is determined, set the temperature and pressure if provided
         if "temperature" in kwargs:
             temperature = kwargs["temperature"]
-            temperature_unit = kwargs.get(
-                "temperature_unit", "K"
-            )  # The unit is optional
+            temperature_unit = kwargs.get("temperature_unit", "K")  # The unit is optional
             self.set_temperature(temperature, temperature_unit)
 
         if "pressure" in kwargs:
             pressure = kwargs["pressure"]
-            pressure_unit = kwargs.get(
-                "pressure_unit", "pascal"
-            )  # The unit is optional
+            pressure_unit = kwargs.get("pressure_unit", "pascal")  # The unit is optional
             self.set_pressure(pressure, pressure_unit)
 
         self._addToRegistry()
@@ -607,11 +597,9 @@ class Element(MaterialBase):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(
-            kwargs.get("name", None),
-            state=kwargs.get("state", None),
-            registry=kwargs.get("registry", None),
-        )
+        super().__init__(kwargs.get("name", None),
+                         state=kwargs.get("state", None),
+                         registry=kwargs.get("registry", None))
 
         self.symbol = kwargs.get("symbol", None)
         self.n_comp = kwargs.get("n_comp", None)


### PR DESCRIPTION
Add comments to all isotopes, elements and materials in the geant4 to fluka conversion. Optional default empty comment for fluka materials.  Fix trailing comma that has been wrongly introduced where no more arguments are meant to be.