### PR TITLE
pycgal : fix mesh orientation with reflections

### DIFF
--- a/src/pyg4ometry/pycgal/CGAL.cxx
+++ b/src/pyg4ometry/pycgal/CGAL.cxx
@@ -114,11 +114,15 @@ PYBIND11_MODULE(CGAL, m) {
       "Is the surface a triangular mesh", py::arg("Surface_mesh_EPICK"));
   m.def(
       "is_outward_oriented",
-      [](Surface_mesh_EPICK &pm) {return CGAL::Polygon_mesh_processing::is_outward_oriented(pm);},
+      [](Surface_mesh_EPICK &pm) {
+        return CGAL::Polygon_mesh_processing::is_outward_oriented(pm);
+      },
       "Is the surface outward oriented", py::arg("Surface_mesh_EPICK"));
   m.def(
       "reverse_face_orientations",
-      [](Surface_mesh_EPICK &pm) {return CGAL::Polygon_mesh_processing::reverse_face_orientations(pm);},
+      [](Surface_mesh_EPICK &pm) {
+        return CGAL::Polygon_mesh_processing::reverse_face_orientations(pm);
+      },
       "Reverse the face orientations ", py::arg("Surface_mesh_EPICK"));
 
   m.def(
@@ -130,11 +134,15 @@ PYBIND11_MODULE(CGAL, m) {
       "Is the surface a triangular mesh", py::arg("Surface_mesh_EPICK"));
   m.def(
       "is_outward_oriented",
-      [](Surface_mesh_EPECK &pm) {return CGAL::Polygon_mesh_processing::is_outward_oriented(pm);},
+      [](Surface_mesh_EPECK &pm) {
+        return CGAL::Polygon_mesh_processing::is_outward_oriented(pm);
+      },
       "Is the surface outward oriented", py::arg("Surface_mesh_EPECK"));
   m.def(
       "reverse_face_orientations",
-      [](Surface_mesh_EPECK &pm) {return CGAL::Polygon_mesh_processing::reverse_face_orientations(pm);},
+      [](Surface_mesh_EPECK &pm) {
+        return CGAL::Polygon_mesh_processing::reverse_face_orientations(pm);
+      },
       "Reverse the face orientations ", py::arg("Surface_mesh_EPECK"));
 
   /* Iterators and circulators */
@@ -343,7 +351,7 @@ PYBIND11_MODULE(CGAL, m) {
                                              "Polyhedral_mesh_domain_3_EPICK")
       .def(py::init<Polyhedron_3_EPICK &>());
   py::class_<Mesh_criteria_3_EPICK>(m, "Mesh_criteria_3_EPICK");
-      //.def(py::init<double, double, double, double, double>());
+  //.def(py::init<double, double, double, double, double>());
   py::class_<Mesh_complex_3_in_triangulation_3_EPICK>(
       m, "Mesh_complex_3_in_triangulation_3_EPICK")
       .def("output_facets_in_complex_to_off",
@@ -381,7 +389,6 @@ PYBIND11_MODULE(CGAL, m) {
            [](CDT2_EPECK &cdt, CDT2_EPECK::Face_handle fh) {
              return cdt.is_infinite(fh);
            })
-
 
       /* Triangulation_2 Access Functions */
       .def("dimension", &CDT2_EPECK::dimension)

--- a/src/pyg4ometry/pycgal/CGAL.cxx
+++ b/src/pyg4ometry/pycgal/CGAL.cxx
@@ -112,6 +112,14 @@ PYBIND11_MODULE(CGAL, m) {
       "is_triangle_mesh",
       [](Surface_mesh_EPICK &pm) { return CGAL::is_triangle_mesh(pm); },
       "Is the surface a triangular mesh", py::arg("Surface_mesh_EPICK"));
+  m.def(
+      "is_outward_oriented",
+      [](Surface_mesh_EPICK &pm) {return CGAL::Polygon_mesh_processing::is_outward_oriented(pm);},
+      "Is the surface outward oriented", py::arg("Surface_mesh_EPICK"));
+  m.def(
+      "reverse_face_orientations",
+      [](Surface_mesh_EPICK &pm) {return CGAL::Polygon_mesh_processing::reverse_face_orientations(pm);},
+      "Reverse the face orientations ", py::arg("Surface_mesh_EPICK"));
 
   m.def(
       "is_closed", [](Surface_mesh_EPECK &pm) { return CGAL::is_closed(pm); },
@@ -120,6 +128,14 @@ PYBIND11_MODULE(CGAL, m) {
       "is_triangle_mesh",
       [](Surface_mesh_EPECK &pm) { return CGAL::is_triangle_mesh(pm); },
       "Is the surface a triangular mesh", py::arg("Surface_mesh_EPICK"));
+  m.def(
+      "is_outward_oriented",
+      [](Surface_mesh_EPECK &pm) {return CGAL::Polygon_mesh_processing::is_outward_oriented(pm);},
+      "Is the surface outward oriented", py::arg("Surface_mesh_EPECK"));
+  m.def(
+      "reverse_face_orientations",
+      [](Surface_mesh_EPECK &pm) {return CGAL::Polygon_mesh_processing::reverse_face_orientations(pm);},
+      "Reverse the face orientations ", py::arg("Surface_mesh_EPECK"));
 
   /* Iterators and circulators */
   m.def(
@@ -326,8 +342,8 @@ PYBIND11_MODULE(CGAL, m) {
   py::class_<Polyhedral_mesh_domain_3_EPICK>(m,
                                              "Polyhedral_mesh_domain_3_EPICK")
       .def(py::init<Polyhedron_3_EPICK &>());
-  // py::class_<Mesh_criteria_3_EPICK>(m, "Mesh_criteria_3_EPICK")
-  //     .def(py::init<double, double, double, double, double>());
+  py::class_<Mesh_criteria_3_EPICK>(m, "Mesh_criteria_3_EPICK");
+      //.def(py::init<double, double, double, double, double>());
   py::class_<Mesh_complex_3_in_triangulation_3_EPICK>(
       m, "Mesh_complex_3_in_triangulation_3_EPICK")
       .def("output_facets_in_complex_to_off",
@@ -365,6 +381,7 @@ PYBIND11_MODULE(CGAL, m) {
            [](CDT2_EPECK &cdt, CDT2_EPECK::Face_handle fh) {
              return cdt.is_infinite(fh);
            })
+
 
       /* Triangulation_2 Access Functions */
       .def("dimension", &CDT2_EPECK::dimension)

--- a/src/pyg4ometry/pycgal/core.py
+++ b/src/pyg4ometry/pycgal/core.py
@@ -139,6 +139,10 @@ class CSG:
         csg.sm = out
         return csg
 
+    def inverse(self):
+        CGAL.reverse_face_orientations(self.sm)
+        return self
+
     # TODO finish coplanar intersection
     def coplanarIntersection(self, csg):
         """

--- a/tests/pycgal/test_cgal_mesh_reflection.py
+++ b/tests/pycgal/test_cgal_mesh_reflection.py
@@ -1,0 +1,15 @@
+import pyg4ometry.pycgal as _cgal
+
+def test_cgal_box_reflection():
+    c = _cgal.CSG.cube([1, 1, 1], [1, 1, 1])
+
+    assert(_cgal.CGAL.is_outward_oriented(c.sm))
+
+    c.scale([-1, -1, -1])
+
+    assert(not _cgal.CGAL.is_outward_oriented(c.sm))
+
+    _cgal.CGAL.reverse_face_orientations(c.sm)
+
+    assert(_cgal.CGAL.is_outward_oriented(c.sm))
+

--- a/tests/pycgal/test_cgal_mesh_reflection.py
+++ b/tests/pycgal/test_cgal_mesh_reflection.py
@@ -1,15 +1,15 @@
 import pyg4ometry.pycgal as _cgal
 
+
 def test_cgal_box_reflection():
     c = _cgal.CSG.cube([1, 1, 1], [1, 1, 1])
 
-    assert(_cgal.CGAL.is_outward_oriented(c.sm))
+    assert _cgal.CGAL.is_outward_oriented(c.sm)
 
     c.scale([-1, -1, -1])
 
-    assert(not _cgal.CGAL.is_outward_oriented(c.sm))
+    assert not _cgal.CGAL.is_outward_oriented(c.sm)
 
     _cgal.CGAL.reverse_face_orientations(c.sm)
 
-    assert(_cgal.CGAL.is_outward_oriented(c.sm))
-
+    assert _cgal.CGAL.is_outward_oriented(c.sm)


### PR DESCRIPTION
- needed a few extra CGAL functions (is_outward_oriented and reverse_face_orientation)
- inverse maps to reverse_face_orientation to keep consistency with pycsg
- added a test but a more complete test is required.