### PR TITLE
docs: pin sphinx to >=7.2.2 in RTD build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,4 +13,4 @@ build:
     python: "3.10"
   jobs:
     post_install:
-      - pip install furo sphinx>=7.2.2 sphinx-autoapi sphinx-copybutton sphinx-inline-tabs
+      - pip install --upgrade --upgrade-strategy only-if-needed furo sphinx>=7.2.2 sphinx-autoapi sphinx-copybutton sphinx-inline-tabs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,4 +13,4 @@ build:
     python: "3.10"
   jobs:
     post_install:
-      - pip install furo sphinx sphinx-autoapi sphinx-copybutton sphinx-inline-tabs
+      - pip install furo sphinx>=7.2.2 sphinx-autoapi sphinx-copybutton sphinx-inline-tabs


### PR DESCRIPTION
fixes #89 

We already had this issue in our other repositories over the last days.