### PR TITLE
pycgal : (feature) Half space upgrades

### DIFF
--- a/src/pyg4ometry/pycgal/CGAL.cxx
+++ b/src/pyg4ometry/pycgal/CGAL.cxx
@@ -7,6 +7,8 @@ namespace py = pybind11;
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Extended_cartesian.h>
 #include <CGAL/Nef_polyhedron_3.h>
 #include <CGAL/Partition_traits_2.h>
 #include <CGAL/Polygon_with_holes_2.h>
@@ -15,8 +17,11 @@ namespace py = pybind11;
 #include <CGAL/Surface_mesh/IO/OFF.h>
 #include <CGAL/partition_2.h>
 
+typedef CGAL::Exact_rational ER;
+typedef CGAL::Extended_cartesian<ER> Kernel_ECER;
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel_EPICK;
 typedef CGAL::Partition_traits_2<Kernel_EPICK> Partition_traits_2_EPICK;
+
 typedef Partition_traits_2_EPICK::Point_2 Partition_traits_2_Point_2_EPICK;
 typedef Partition_traits_2_EPICK::Polygon_2 Partition_traits_2_Polygon_2_EPICK;
 typedef Kernel_EPICK::Point_2 Point_2_EPICK;
@@ -40,6 +45,11 @@ typedef CGAL::Polygon_with_holes_2<Kernel_EPECK> Polygon_with_holes_2_EPECK;
 typedef CGAL::Polyhedron_3<Kernel_EPECK> Polyhedron_3_EPECK;
 typedef CGAL::Surface_mesh<Kernel_EPECK::Point_3> Surface_mesh_EPECK;
 typedef CGAL::Nef_polyhedron_3<Kernel_EPECK> Nef_polyhedron_3_EPECK;
+
+typedef Kernel_ECER::Point_3 Point_ECER;
+typedef Kernel_ECER::Vector_3 Vector_ECER;
+typedef CGAL::Polyhedron_3<Kernel_ECER> Polyhedron_3_ECER;
+typedef CGAL::Surface_mesh<Point_ECER> Surface_mesh_ECER;
 
 #include <CGAL/Polygon_mesh_processing/orientation.h>
 #include <CGAL/aff_transformation_tags.h>
@@ -187,6 +197,13 @@ PYBIND11_MODULE(CGAL, m) {
   m.def("copy_face_graph", [](Polyhedron_3_EPECK &p1, Polyhedron_3_EPICK &p2) {
     return CGAL::copy_face_graph(p1, p2);
   });
+  m.def("copy_face_graph", [](Polyhedron_3_ECER &p1, Surface_mesh_ECER &sm2) {
+    return CGAL::copy_face_graph(p1, sm2);
+  });
+  // m.def("copy_face_graph", [](Polyhedron_3_ECER &p1, Polyhedron_3_EPICK &p2)
+  // {
+  //   return CGAL::copy_face_graph(p1, p2);
+  // });
 
   /* 2D boolean */
   m.def("do_intersect", [](Polygon_2_EPECK &p1, Polygon_2_EPECK &p2) {

--- a/src/pyg4ometry/pycgal/HalfPlane.py
+++ b/src/pyg4ometry/pycgal/HalfPlane.py
@@ -1,0 +1,31 @@
+from .Point_3 import Point_3_ECER as _Point_3_ECER
+from .Vector_3 import Vector_3_ECER as _Vector_3_ECER
+from .Plane_3 import Plane_3_ECER as _Plane_3_ECER
+from .Nef_polyhedron_3 import Nef_polyhedron_3_ECER as _Nef_polyhedron_3_ECER
+from .Polyhedron_3 import Polyhedron_3_ECER as _Polyhedron_3_ECER
+import pyg4ometry.pycgal.Surface_mesh
+from .Surface_mesh import Surface_mesh_ECER as _Surface_mesh_ECER
+from .Surface_mesh import Surface_mesh_EPECK as _Surface_mesh_EPECK
+from .CGAL import copy_face_graph as _copy_face_graph
+
+
+def halfPlaneMesh(planes=None):
+    n1 = _Nef_polyhedron_3_ECER(_Plane_3_ECER(_Point_3_ECER(0, 0, 1), _Vector_3_ECER(0, 0, 1)))
+    n2 = _Nef_polyhedron_3_ECER(_Plane_3_ECER(_Point_3_ECER(0, 0, -1), _Vector_3_ECER(0, 0, -1)))
+    n3 = _Nef_polyhedron_3_ECER(_Plane_3_ECER(_Point_3_ECER(0, 1, 0), _Vector_3_ECER(0, 1, 0)))
+    n4 = _Nef_polyhedron_3_ECER(_Plane_3_ECER(_Point_3_ECER(0, -1, 0), _Vector_3_ECER(0, -1, 0)))
+    n5 = _Nef_polyhedron_3_ECER(_Plane_3_ECER(_Point_3_ECER(1, 0, 0), _Vector_3_ECER(1, 0, 0)))
+    n6 = _Nef_polyhedron_3_ECER(_Plane_3_ECER(_Point_3_ECER(-1, 0, 0), _Vector_3_ECER(-1, 0, 0)))
+
+    n = n1 * n2 * n3 * n4 * n5 * n6
+
+    p = _Polyhedron_3_ECER()
+    n.convert_to_polyhedron(p)
+
+    sm_ecer = _Surface_mesh_ECER()
+    sm_epeck = _Surface_mesh_EPECK()
+
+    _copy_face_graph(p, sm_ecer)
+    pyg4ometry.pycgal.Surface_mesh.toCGALSurfaceMesh(sm_epeck, sm_ecer)
+
+    return sm_epeck

--- a/src/pyg4ometry/pycgal/Nef_polyhedron_3.cxx
+++ b/src/pyg4ometry/pycgal/Nef_polyhedron_3.cxx
@@ -1,3 +1,4 @@
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
@@ -5,6 +6,8 @@ namespace py = pybind11;
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Extended_cartesian.h>
 
 #include <CGAL/Nef_polyhedron_3.h>
 #include <CGAL/Polyhedron_incremental_builder_3.h>
@@ -12,6 +15,7 @@ namespace py = pybind11;
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel_EPECK;
 typedef Kernel_EPECK::Point_3 Point_EPECK;
 typedef Kernel_EPECK::Vector_3 Vector_EPECK;
+typedef Kernel_EPECK::Plane_3 Plane_EPECK;
 typedef CGAL::Polyhedron_3<Kernel_EPECK> Polyhedron_3_EPECK;
 typedef CGAL::Nef_polyhedron_3<Kernel_EPECK> Nef_polyhedron_3_EPECK;
 typedef Nef_polyhedron_3_EPECK::Volume_const_iterator
@@ -22,6 +26,7 @@ typedef Nef_polyhedron_3_EPECK::Shell_entry_const_iterator
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel_EPICK;
 typedef Kernel_EPICK::Point_3 Point_EPICK;
 typedef Kernel_EPICK::Vector_3 Vector_EPICK;
+typedef Kernel_EPICK::Plane_3 Plane_EPICK;
 typedef CGAL::Polyhedron_3<Kernel_EPICK> Polyhedron_3_EPICK;
 typedef CGAL::Nef_polyhedron_3<Kernel_EPICK> Nef_polyhedron_3_EPICK;
 typedef Nef_polyhedron_3_EPICK::Volume_const_iterator
@@ -29,10 +34,17 @@ typedef Nef_polyhedron_3_EPICK::Volume_const_iterator
 typedef Nef_polyhedron_3_EPICK::Shell_entry_const_iterator
     Nef_polyhedron_3_EPICK_Shell_entry_iterator;
 
+typedef CGAL::Exact_rational ER;
+typedef CGAL::Extended_cartesian<ER> Kernel_ECER;
+typedef CGAL::Nef_polyhedron_3<Kernel_ECER> Nef_polyhedron_3_ECER;
+typedef Kernel_ECER::Plane_3 Plane_3_ECER;
+typedef CGAL::Polyhedron_3<Kernel_ECER> Polyhedron_3_ECER;
+
 PYBIND11_MODULE(Nef_polyhedron_3, m) {
   py::class_<Nef_polyhedron_3_EPECK>(m, "Nef_polyhedron_3_EPECK")
       .def(py::init<>())
       .def(py::init<Polyhedron_3_EPECK &>())
+      .def(py::init<Plane_EPECK &>())
       /* Access Member Functions */
       .def("is_simple", &Nef_polyhedron_3_EPECK::is_simple)
       .def("is_valid", &Nef_polyhedron_3_EPECK::is_valid)
@@ -92,6 +104,7 @@ PYBIND11_MODULE(Nef_polyhedron_3, m) {
   py::class_<Nef_polyhedron_3_EPICK>(m, "Nef_polyhedron_3_EPICK")
       .def(py::init<>())
       .def(py::init<Polyhedron_3_EPICK &>())
+      .def(py::init<Plane_EPICK &>())
       /* Access Member Functions */
       .def("is_simple", &Nef_polyhedron_3_EPICK::is_simple)
       .def("is_valid", &Nef_polyhedron_3_EPICK::is_valid)
@@ -141,4 +154,28 @@ PYBIND11_MODULE(Nef_polyhedron_3, m) {
                         Nef_polyhedron_3_EPICK_Shell_entry_iterator i2) {
         return i1 != i2;
       });
+
+  py::class_<Nef_polyhedron_3_ECER>(m, "Nef_polyhedron_3_ECER")
+      .def(py::init<>())
+      .def(py::init<Plane_3_ECER &>())
+      .def("is_simple", &Nef_polyhedron_3_ECER::is_simple)
+      .def("is_valid", &Nef_polyhedron_3_ECER::is_valid)
+      .def("number_of_vertices", &Nef_polyhedron_3_ECER::number_of_vertices)
+      .def("number_of_halfedges", &Nef_polyhedron_3_ECER::number_of_halfedges)
+      .def("number_of_edges", &Nef_polyhedron_3_ECER::number_of_edges)
+      .def("number_of_halffacets", &Nef_polyhedron_3_ECER::number_of_halffacets)
+      .def("number_of_facets", &Nef_polyhedron_3_ECER::number_of_facets)
+      .def("number_of_volumes", &Nef_polyhedron_3_ECER::number_of_volumes)
+
+      .def("convert_to_polyhedron",
+           [](Nef_polyhedron_3_ECER &np, Polyhedron_3_ECER &p) {
+             np.convert_to_polyhedron(p);
+           })
+
+      .def(py::self * py::self)
+      .def(py::self *= py::self)
+      .def(py::self + py::self)
+      .def(py::self += py::self)
+      .def(py::self - py::self)
+      .def(py::self -= py::self);
 }

--- a/src/pyg4ometry/pycgal/Plane_3.cxx
+++ b/src/pyg4ometry/pycgal/Plane_3.cxx
@@ -7,12 +7,18 @@ namespace py = pybind11;
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Extended_cartesian.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel_EPICK;
 typedef Kernel_EPICK::Plane_3 Plane_3_EPICK;
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel_EPECK;
 typedef Kernel_EPECK::Plane_3 Plane_3_EPECK;
+
+typedef CGAL::Exact_rational ER;
+typedef CGAL::Extended_cartesian<ER> Kernel_ECER;
+typedef Kernel_ECER::Plane_3 Plane_3_ECER;
 
 PYBIND11_MODULE(Plane_3, m) {
   py::class_<Plane_3_EPICK>(m, "Plane_3_EPICK")
@@ -135,6 +141,9 @@ PYBIND11_MODULE(Plane_3, m) {
 
       /* Miscellaneous */
       .def("transform", &Plane_3_EPECK::transform);
+
+  py::class_<Plane_3_ECER>(m, "Plane_3_ECER")
+      .def(py::init<const Kernel_ECER::Point_3, const Kernel_ECER::Vector_3>());
 
   /* pybdind11 only */
 }

--- a/src/pyg4ometry/pycgal/Point_3.cxx
+++ b/src/pyg4ometry/pycgal/Point_3.cxx
@@ -7,6 +7,8 @@ namespace py = pybind11;
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Extended_cartesian.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel_EPICK;
 typedef Kernel_EPICK::Point_3 Point_3_EPICK;
@@ -15,6 +17,11 @@ typedef Kernel_EPICK::Vector_3 Vector_3_EPICK;
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel_EPECK;
 typedef Kernel_EPECK::Point_3 Point_3_EPECK;
 typedef Kernel_EPECK::Vector_3 Vector_3_EPECK;
+
+typedef CGAL::Exact_rational ER;
+typedef CGAL::Extended_cartesian<ER> Kernel_ECER;
+typedef Kernel_ECER::Point_3 Point_3_ECER;
+typedef Kernel_ECER::Vector_3 Vector_3_ECER;
 
 PYBIND11_MODULE(Point_3, m) {
 
@@ -171,4 +178,8 @@ PYBIND11_MODULE(Point_3, m) {
            << CGAL::to_double(p1.y()) << " " << CGAL::to_double(p1.y());
         return ss.str();
       });
+
+  py::class_<Point_3_ECER>(m, "Point_3_ECER")
+      .def(py::init<>())
+      .def(py::init<double, double, double>());
 }

--- a/src/pyg4ometry/pycgal/Polygon_mesh_processing.cxx
+++ b/src/pyg4ometry/pycgal/Polygon_mesh_processing.cxx
@@ -7,6 +7,8 @@ namespace py = pybind11;
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Extended_cartesian.h>
 #include <CGAL/Surface_mesh.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel_EPICK;
@@ -19,10 +21,16 @@ typedef Kernel_EPECK::Point_3 Point_3_EPECK;
 typedef Kernel_EPECK::Vector_3 Vector_3_EPECK;
 typedef CGAL::Surface_mesh<Kernel_EPECK::Point_3> Surface_mesh_EPECK;
 
+typedef CGAL::Extended_cartesian<CGAL::Exact_rational> Kernel_ECER;
+typedef Kernel_ECER::Point_3 Point_3_ECER;
+typedef Kernel_ECER::Vector_3 Vector_3_ECER;
+typedef CGAL::Surface_mesh<Kernel_ECER::Point_3> Surface_mesh_ECER;
+
 #include <CGAL/Aff_transformation_3.h>
 
 typedef CGAL::Aff_transformation_3<Kernel_EPICK> Aff_transformation_3_EPICK;
 typedef CGAL::Aff_transformation_3<Kernel_EPECK> Aff_transformation_3_EPECK;
+typedef CGAL::Aff_transformation_3<Kernel_ECER> Aff_transformation_3_ECER;
 
 #include <CGAL/Polygon_mesh_processing/border.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
@@ -36,6 +44,11 @@ typedef CGAL::Aff_transformation_3<Kernel_EPECK> Aff_transformation_3_EPECK;
 #include <CGAL/Polygon_mesh_processing/smooth_shape.h>
 
 PYBIND11_MODULE(Polygon_mesh_processing, m) {
+
+  /**********************************************************************
+  EPICK
+  **********************************************************************/
+
   m.doc() = "CGAL Polygon mesh processing";
   m.def(
       "reverse_face_orientations",
@@ -101,6 +114,10 @@ PYBIND11_MODULE(Polygon_mesh_processing, m) {
   });
   */
 
+  /**********************************************************************
+  EPECK
+  **********************************************************************/
+
   m.def(
       "reverse_face_orientations",
       [](Surface_mesh_EPECK &pm) {
@@ -147,20 +164,41 @@ PYBIND11_MODULE(Polygon_mesh_processing, m) {
         CGAL::parameters::number_of_iterations(nb_iter).protect_constraints(
             true));
   });
+
+  /**********************************************************************
+  ECER
+  **********************************************************************/
   /*
-  m.def("angle_and_area_smoothing", [](Surface_mesh_EPECK &pm1, int nb_iter) {
-    return CGAL::Polygon_mesh_processing::angle_and_area_smoothing(pm1,
-                                                                   CGAL::parameters::number_of_iterations(nb_iter));
+  m.def(
+      "reverse_face_orientations",
+      [](Surface_mesh_ECER &pm) {
+        CGAL::Polygon_mesh_processing::reverse_face_orientations(pm);
+      },
+      "Reverse all face orientations", py::arg("Surface_mesh"));
+  m.def("transform",
+        [](Aff_transformation_3_ECER &transl, Surface_mesh_ECER &sm) {
+          CGAL::Polygon_mesh_processing::transform(transl, sm);
+        });
+  m.def("corefine_and_compute_union", [](Surface_mesh_ECER &pm1,
+                                         Surface_mesh_ECER &pm2,
+                                         Surface_mesh_ECER &out) {
+    CGAL::Polygon_mesh_processing::corefine_and_compute_union(pm1, pm2, out);
   });
-  m.def("tangential_relaxation", [](Surface_mesh_EPECK &pm1, int nb_iter) {
-    return CGAL::Polygon_mesh_processing::tangential_relaxation(pm1,
-                                                                CGAL::parameters::number_of_iterations(nb_iter));
+
+  m.def("corefine_and_compute_intersection", [](Surface_mesh_ECER &pm1,
+                                                Surface_mesh_ECER &pm2,
+                                                Surface_mesh_ECER &out) {
+    CGAL::Polygon_mesh_processing::corefine_and_compute_intersection(pm1, pm2,
+                                                                     out);
   });
-  m.def("smooth_shape", [](Surface_mesh_EPECK &pm1, double time, int nb_iter) {
-    return CGAL::Polygon_mesh_processing::smooth_shape(faces(pm1),
-                                                       pm1,
-                                                       time,
-                                                       CGAL::parameters::number_of_iterations(nb_iter));
+  m.def("corefine_and_compute_difference", [](Surface_mesh_ECER &pm1,
+                                              Surface_mesh_ECER &pm2,
+                                              Surface_mesh_ECER &out) {
+    CGAL::Polygon_mesh_processing::corefine_and_compute_difference(pm1, pm2,
+                                                                   out);
+  });
+  m.def("do_intersect", [](Surface_mesh_ECER &pm1, Surface_mesh_ECER &pm2) {
+    return CGAL::Polygon_mesh_processing::do_intersect(pm1, pm2);
   });
   */
 }

--- a/src/pyg4ometry/pycgal/Polyhedron_3.cxx
+++ b/src/pyg4ometry/pycgal/Polyhedron_3.cxx
@@ -8,6 +8,8 @@ namespace py = pybind11;
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Extended_cartesian.h>
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_incremental_builder_3.h>
@@ -23,6 +25,12 @@ typedef Kernel_EPICK::Point_3 Point_EPICK;
 typedef Kernel_EPICK::Vector_3 Vector_EPICK;
 typedef CGAL::Polyhedron_3<Kernel_EPICK> Polyhedron_3_EPICK;
 typedef Polyhedron_3_EPICK::HalfedgeDS HalfedgeDS_EPICK;
+
+typedef CGAL::Exact_rational ER;
+typedef CGAL::Extended_cartesian<ER> Kernel_ECER;
+typedef Kernel_ECER::Point_3 Point_ECER;
+typedef Kernel_ECER::Vector_3 Vector_ECER;
+typedef CGAL::Polyhedron_3<Kernel_ECER> Polyhedron_3_ECER;
 
 PYBIND11_MAKE_OPAQUE(std::vector<Polyhedron_3_EPICK>);
 PYBIND11_MAKE_OPAQUE(std::vector<Polyhedron_3_EPECK>);
@@ -220,4 +228,9 @@ PYBIND11_MODULE(Polyhedron_3, m) {
                                                    "Vector_Polyhedron_3_EPECK");
   py::bind_vector<std::vector<Polyhedron_3_EPICK>>(m,
                                                    "Vector_Polyhedron_3_EPICK");
+
+  py::class_<Polyhedron_3_ECER>(m, "Polyhedron_3_ECER")
+      .def(py::init<>())
+      .def("size_of_vertices", &Polyhedron_3_ECER::size_of_vertices)
+      .def("size_of_facets", &Polyhedron_3_ECER::size_of_facets);
 }

--- a/src/pyg4ometry/pycgal/Vector_3.cxx
+++ b/src/pyg4ometry/pycgal/Vector_3.cxx
@@ -8,12 +8,18 @@ namespace py = pybind11;
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Extended_cartesian.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel_EPICK;
 typedef Kernel_EPICK::Vector_3 Vector_3_EPICK;
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel_EPECK;
 typedef Kernel_EPECK::Vector_3 Vector_3_EPECK;
+
+typedef CGAL::Exact_rational ER;
+typedef CGAL::Extended_cartesian<ER> Kernel_ECER;
+typedef Kernel_ECER::Vector_3 Vector_3_ECER;
 
 PYBIND11_MODULE(Vector_3, m) {
   py::class_<Vector_3_EPICK>(m, "Vector_3_EPICK")
@@ -208,4 +214,8 @@ PYBIND11_MODULE(Vector_3, m) {
            << CGAL::to_double(v1.y()) << " " << CGAL::to_double(v1.y());
         return ss.str();
       });
+
+  py::class_<Vector_3_ECER>(m, "Vector_3_ECER")
+      .def(py::init<>())
+      .def(py::init<double, double, double>());
 }

--- a/src/pyg4ometry/pycgal/__init__.py
+++ b/src/pyg4ometry/pycgal/__init__.py
@@ -24,6 +24,7 @@ from . import Nef_polyhedron_3
 from . import Surface_mesh
 from . import Polygon_mesh_processing
 from . import pythonHelpers
+from . import HalfPlane
 
 
 from .core import *


### PR DESCRIPTION
H-Rep (half space) representation code. What is needed for CAD to FLUKA conversion
- Extended Cartesian exact rational ECER kernel
- Standard classes using ECER kernel (Nef_polyhedron, Polyhedron, Surface_mesh)
- Conversion from Surface_mesh_EPECK to _ECER