### PR TITLE
Update GDML xsd schema location

### DIFF
--- a/src/pyg4ometry/gdml/Writer.py
+++ b/src/pyg4ometry/gdml/Writer.py
@@ -18,7 +18,7 @@ class Writer:
         self.top.setAttribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
         self.top.setAttribute(
             "xsi:noNamespaceSchemaLocation",
-            "http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd",
+            "http://cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd",
         )
 
         self.defines = self.top.appendChild(self.doc.createElement("define"))


### PR DESCRIPTION
this changed in GDML 3.1.7, bundled with Geant4 11.2.2

see https://github.com/Geant4/geant4/blob/e58e650b32b961c8093f3dd6a2c3bc917b2552be/source/persistency/gdml/include/G4GDMLParser.hh#L47-L50