### PR TITLE
Remove python3.8 and pygltflib 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "cython",
     "pybind11>=2.6",
-    "setuptools>=42",
+    "setuptools>=70",
     "packaging>=20",
     "setuptools_scm[toml]>=3.4",
     "scikit-build-core==0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 requires = [
     "cython",
     "pybind11>=2.6",
-    "setuptools>=70",
+    "setuptools>=42",
+    "packaging",
     "setuptools_scm[toml]>=3.4",
     "scikit-build-core==0.5",
     "antlr4-tools==0.2.1",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "sympy>=1.7",
     "testtools",
     "vtk",
+    "pygltflib==1.16.1"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "cython",
     "pybind11>=2.6",
-    "setuptools>=42",
+    "setuptools>=72",
     "setuptools_scm[toml]>=3.4",
     "scikit-build-core==0.5",
     "antlr4-tools==0.2.1",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,7 @@ dependencies = [
     "scipy",
     "sympy>=1.7",
     "testtools",
-    "vtk",
-    "pygltflib==1.15.0" # pinned at this version as setuptools error for 1.16.2, 1.16.1, 1.16.0
+    "vtk"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "cython",
     "pybind11>=2.6",
     "setuptools>=42",
-    "packaging",
+    "packaging>=20",
     "setuptools_scm[toml]>=3.4",
     "scikit-build-core==0.5",
     "antlr4-tools==0.2.1",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "sympy>=1.7",
     "testtools",
     "vtk",
-    "pygltflib==1.15.6" # pinned at this version as setuptools error for 1.16.2, 1.16.1, 1.16.0
+    "pygltflib==1.15.0" # pinned at this version as setuptools error for 1.16.2, 1.16.1, 1.16.0
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "sympy>=1.7",
     "testtools",
     "vtk",
-    "pygltflib==1.16.1"
+    "pygltflib==1.16.0" # pinned at this version as setuptools error for 1.16.2, 1.16.1
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "cython",
     "pybind11>=2.6",
-    "setuptools>=72",
+    "setuptools>=70",
     "setuptools_scm[toml]>=3.4",
     "scikit-build-core==0.5",
     "antlr4-tools==0.2.1",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,7 @@ dependencies = [
     "scipy",
     "sympy>=1.7",
     "testtools",
-    "vtk==9.3.0",
-    "pygltflib"
+    "vtk",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "sympy>=1.7",
     "testtools",
     "vtk",
-    "pygltflib==1.16.0" # pinned at this version as setuptools error for 1.16.2, 1.16.1
+    "pygltflib==1.15.6" # pinned at this version as setuptools error for 1.16.2, 1.16.1, 1.16.0
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 requires = [
     "cython",
     "pybind11>=2.6",
-    "setuptools>=70",
-    "packaging>=20",
+    "setuptools>=42",
     "setuptools_scm[toml]>=3.4",
     "scikit-build-core==0.5",
     "antlr4-tools==0.2.1",]
@@ -46,7 +45,7 @@ dependencies = [
     "scipy",
     "sympy>=1.7",
     "testtools",
-    "vtk",
+    "vtk==9.3.0",
     "pygltflib"
 ]
 


### PR DESCRIPTION
Mac python 3.8 does not have suitable VTK... probably ok to remove python 3.8 now. A optional dep (pygltflib) causes docker test environment to fail