### PR TITLE
CI/CD: proper mac python versions

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -77,7 +77,9 @@ jobs:
         id: cpu-cores
 
       - name: Build MacOS wheel ${{ matrix.python-version }}
-        run: pipx run build --wheel
+        run: |
+          ${{ steps.setup-python.outputs.python-path}} -m pip install build
+          ${{ steps.setup-python.outputs.python-path}} -m build .
 
       - name: Upload macos artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Need to select correct Mac python for creating wheels