### PR TITLE
fix VtkViewerNew for VTK 9.4.0

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,4 +13,4 @@ build:
     python: "3.10"
   jobs:
     post_install:
-      - pip install --upgrade --upgrade-strategy only-if-needed furo sphinx>=7.2.2 sphinx-autoapi<3.4.0 sphinx-copybutton sphinx-inline-tabs
+      - pip install --upgrade --upgrade-strategy only-if-needed furo "sphinx>=7.2.2" "sphinx-autoapi<3.4.0" sphinx-copybutton sphinx-inline-tabs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,4 +13,4 @@ build:
     python: "3.10"
   jobs:
     post_install:
-      - pip install --upgrade --upgrade-strategy only-if-needed furo sphinx>=7.2.2 sphinx-autoapi sphinx-copybutton sphinx-inline-tabs
+      - pip install --upgrade --upgrade-strategy only-if-needed furo sphinx>=7.2.2 sphinx-autoapi<3.4.0 sphinx-copybutton sphinx-inline-tabs

--- a/src/pyg4ometry/visualisation/VtkViewerNew.py
+++ b/src/pyg4ometry/visualisation/VtkViewerNew.py
@@ -56,7 +56,6 @@ class VtkViewerNew(_ViewerBase):
         self.clippers = []  # clip filters
         self.axes = []  # axes actors
 
-        self.pdNameDict = {}  # polydata to LV name
         self.instanceNameDict = {}  # instance transformation to PV name
 
         self.bBuiltPipelines = False
@@ -326,7 +325,6 @@ class VtkViewerNew(_ViewerBase):
             pd = _Convert.pycsgMeshToVtkPolyData(self.localmeshes[k])
             # pd.SetObjectName(k)
             self.polydata[k] = pd
-            self.pdNameDict[pd] = k
 
         appFltDict = {}
         visOptDict = {}
@@ -708,7 +706,9 @@ class MouseInteractorNamePhysicalVolume(_vtk.vtkInteractorStyleTrackballCamera):
                 pdmin = pd
                 pdamin = pda
 
-        lvName = self.vtkviewer.pdNameDict[pdamin.GetInputAlgorithm().GetInput()]
+        for name, pd in self.vtkviewer.polydata.items():
+            if pd == pdamin.GetInputAlgorithm().GetInput():
+                lvName = name
         pvName = self.vtkviewer.instanceNameDict[pdamin]
         pvTrans = pdamin.GetTransform()
         [mtra, tra] = _Convert.vtkTransformation2PyG4(pvTrans.GetConcatenatedTransform(0))


### PR DESCRIPTION
this should fix:
```
FAILED tests/fluka/test_Fluka.py::test_fluka_vis - TypeError: unhashable type: 'PolyData'
FAILED tests/visualisation/test_Convert.py::test_vtkPolyDataToNumpy - TypeError: unhashable type: 'PolyData'
FAILED tests/visualisation/test_Visualisation.py::test_VtkViewerNewAppend - TypeError: unhashable type: 'PolyData'
FAILED tests/visualisation/test_Visualisation.py::test_VtkViewerColouredNewAppend - TypeError: unhashable type: 'PolyData'
FAILED tests/visualisation/test_Visualisation.py::test_VtkViewerColouredMaterialNewAppend - TypeError: unhashable type: 'PolyData'
```