### PR TITLE
remove some verbose print() calls

### DIFF
--- a/src/pyg4ometry/analysis/Data.py
+++ b/src/pyg4ometry/analysis/Data.py
@@ -29,7 +29,7 @@ def _warn_import_failed():
     global _import_failed
     if _import_failed != []:
         msg = f"Failed to import {_import_failed}"
-        log.warning(msg)
+        _log.warning(msg)
         _import_failed = []
 
 

--- a/src/pyg4ometry/analysis/Data.py
+++ b/src/pyg4ometry/analysis/Data.py
@@ -25,6 +25,14 @@ except ImportError:
 _log = logging.getLogger(__name__)
 
 
+def _warn_import_failed():
+    global _import_failed
+    if _import_failed != []:
+        msg = f"Failed to import {_import_failed}"
+        log.warning(msg)
+        _import_failed = []
+
+
 class TH1:
     def __init__(self, data, nPrimary=1, flukaBdxVariable="energy"):
         self.name = None
@@ -37,10 +45,7 @@ class TH1:
         self.xlowedges = None
         self.xhighedges = None
 
-        if _import_failed != []:
-            msg = f"Failed to import {_import_failed}"
-            log.warning(msg)
-            _import_failed = []
+        _warn_import_failed()
 
         if type(data) is _FlukaBdxData:
             print("flukaBdxData")
@@ -89,10 +94,7 @@ class TH1:
 
 class TH2:
     def __init__(self, data, nPrimary=1):
-        if _import_failed != []:
-            msg = f"Failed to import {_import_failed}"
-            log.warning(msg)
-            _import_failed = []
+        _warn_import_failed()
 
         if type(data) is _TH2:
             self.name = data.name
@@ -128,10 +130,7 @@ class TH2:
 
 class TH3:
     def __init__(self, data, nPrimary=1):
-        if _import_failed != []:
-            msg = f"Failed to import {_import_failed}"
-            log.warning(msg)
-            _import_failed = []
+        _warn_import_failed()
 
         if type(data) is _FlukaBinData:
             self.name = data.name.strip()

--- a/src/pyg4ometry/analysis/Data.py
+++ b/src/pyg4ometry/analysis/Data.py
@@ -1,14 +1,16 @@
+import logging
 import numpy as _np
 import matplotlib.pyplot as _plt
 from ..analysis.flukaData import FlukaBdxData as _FlukaBdxData
 from ..analysis.flukaData import FlukaBinData as _FlukaBinData
 
+_import_failed = []
 try:
     from pybdsim.Data import TH1 as _TH1
     from pybdsim.Data import TH2 as _TH2
     from pybdsim.Data import TH3 as _TH3
 except ImportError:
-    print("Failed to find pybdsim")
+    _import_failed.append("pybdsim")
 
 try:
     from ROOT import TH1D as _TH1D
@@ -18,7 +20,9 @@ try:
     from ROOT import TH2F as _TH2F
     from ROOT import TH3F as _TH3F
 except ImportError:
-    print("Failed to find ROOT")
+    _import_failed.append("ROOT")
+
+_log = logging.getLogger(__name__)
 
 
 class TH1:
@@ -32,6 +36,11 @@ class TH1:
         self.xedges = None
         self.xlowedges = None
         self.xhighedges = None
+
+        if _import_failed != []:
+            msg = f"Failed to import {_import_failed}"
+            log.warning(msg)
+            _import_failed = []
 
         if type(data) is _FlukaBdxData:
             print("flukaBdxData")
@@ -80,6 +89,11 @@ class TH1:
 
 class TH2:
     def __init__(self, data, nPrimary=1):
+        if _import_failed != []:
+            msg = f"Failed to import {_import_failed}"
+            log.warning(msg)
+            _import_failed = []
+
         if type(data) is _TH2:
             self.name = data.name
             self.nPrimary = nPrimary
@@ -114,6 +128,11 @@ class TH2:
 
 class TH3:
     def __init__(self, data, nPrimary=1):
+        if _import_failed != []:
+            msg = f"Failed to import {_import_failed}"
+            log.warning(msg)
+            _import_failed = []
+
         if type(data) is _FlukaBinData:
             self.name = data.name.strip()
             self.nPrimary = data

--- a/src/pyg4ometry/visualisation/UsdViewer.py
+++ b/src/pyg4ometry/visualisation/UsdViewer.py
@@ -1,9 +1,7 @@
 try:
     from pxr import Usd, Gf, UsdGeom, UsdShade, Sdf
-
-    print("Openusd pyg4ometry imported")
 except ImportError:
-    pass
+    Usd = None
 
 from .ViewerHierarchyBase import ViewerHierarchyBase as _ViewerHierarchyBase
 import numpy as _np
@@ -69,6 +67,9 @@ def visOptions2MaterialPrim(stage, visOptions, materialPrim):
 class UsdViewer(_ViewerHierarchyBase):
 
     def __init__(self, filePath="./test.usd"):
+        if Usd is None:
+            msg = "Failed to import open usd"
+            raise RuntimeError(msg)
 
         self.filePath = filePath
 


### PR DESCRIPTION
I focused on the small number of print statements that are always triggered with our usage, but that do not provide any additional value to us.

I replaced the prints in the global scope with warnings or exceptions that are only triggered if the user attempts to use the data structures that depend on the imported modules.