### PR TITLE
Read and Write GDML colour from/to BDSIM and generally.

### DIFF
--- a/src/pyg4ometry/fluka/Writer.py
+++ b/src/pyg4ometry/fluka/Writer.py
@@ -28,7 +28,7 @@ class Writer:
     Class to write FLUKA input files from a fluka registry object.
 
     >>> f = Writer()
-    >>> f.addDetectro(flukaRegObject)
+    >>> f.addDetector(flukaRegObject)
     >>> f.write("model.inp")
     """
 

--- a/src/pyg4ometry/gdml/Reader.py
+++ b/src/pyg4ometry/gdml/Reader.py
@@ -35,8 +35,12 @@ class Reader:
     """
 
     def __init__(
-        self, fileName, registryOn=True, skipMaterials=False, reduceNISTMaterialsToPredefined=False,
-            makeAllVisible=False
+        self,
+        fileName,
+        registryOn=True,
+        skipMaterials=False,
+        reduceNISTMaterialsToPredefined=False,
+        makeAllVisible=False,
     ):
         super().__init__()
         self.filename = fileName
@@ -2951,6 +2955,7 @@ def _StripPointer(name):
     pattern = r"(0x\w{7,})"
     rNameToObject = _re.sub(pattern, "", name)
     return rNameToObject
+
 
 def _BDSIM_VRGBA(s):
     sl = s.split()

--- a/src/pyg4ometry/gdml/Reader.py
+++ b/src/pyg4ometry/gdml/Reader.py
@@ -24,6 +24,8 @@ class Reader:
     :type registryOn: bool
     :param reduceNISTMaterialsToPredefined: change NIST-named materials to predefined ones
     :type reduceNISTMaterialsToPredefined: bool
+    :param makeAllVisible: loaded volumes with aux info to make them invisible will be ignored and made visible
+    :type makeAllVisible: bool
 
     When loading a GDML file that was exported by Geant4, the NIST materials may be
     fully expanded to include their full element / isotope composition. With the
@@ -33,12 +35,15 @@ class Reader:
     """
 
     def __init__(
-        self, fileName, registryOn=True, skipMaterials=False, reduceNISTMaterialsToPredefined=False
+        self, fileName, registryOn=True, skipMaterials=False, reduceNISTMaterialsToPredefined=False,
+            makeAllVisible=False
     ):
         super().__init__()
         self.filename = fileName
         self.registryOn = registryOn
         self._reduceNISTMaterialsToPredefined = reduceNISTMaterialsToPredefined
+        self._makeAllVisible = makeAllVisible
+        self._forcedVisibleOptions = _VisOptions(alpha=0.1)
         self._skipMaterials = skipMaterials
 
         if self.registryOn:
@@ -1871,6 +1876,8 @@ class Reader:
                                 aux = self._parseAuxiliary(aux_node, register=False)
                                 if aux.auxtype == "bds_vrgba":
                                     visOptions = _BDSIM_VRGBA(aux.auxvalue)
+                                    if not visOptions.visible and self._makeAllVisible:
+                                        visOptions = self._forcedVisibleOptions
                                 aux_list.append(aux)
                         except AttributeError:
                             pass  # probably a comment

--- a/src/pyg4ometry/gdml/Reader.py
+++ b/src/pyg4ometry/gdml/Reader.py
@@ -2947,7 +2947,7 @@ def _StripPointer(name):
 
 def _BDSIM_VRGBA(s):
     sl = s.split()
-    visible = bool(sl[0])
-    rgb = map(float, sl[1:3])
+    visible = bool(int(sl[0]))
+    rgb = list(map(float, sl[1:4]))
     a = float(sl[4])
     return _VisOptions(colour=rgb, alpha=a, visible=visible)

--- a/src/pyg4ometry/gdml/Writer.py
+++ b/src/pyg4ometry/gdml/Writer.py
@@ -384,7 +384,7 @@ option, physicsList="em";
         # ensure it's a list, even if empty
         if lv.auxiliary:
             if type(lv.auxiliary) in (list, tuple):
-                aux = list(lv.auxiliary) # ensure it's of type list
+                aux = list(lv.auxiliary)  # ensure it's of type list
             else:
                 aux = [lv.auxiliary]
         if self._writeColour and lv.visOptions:

--- a/src/pyg4ometry/gdml/Writer.py
+++ b/src/pyg4ometry/gdml/Writer.py
@@ -384,7 +384,7 @@ option, physicsList="em";
         # ensure it's a list, even if empty
         if lv.auxiliary:
             if type(lv.auxiliary) in (list, tuple):
-                aux = list(*lv.auxiliary)
+                aux = list(lv.auxiliary) # ensure it's of type list
             else:
                 aux = [lv.auxiliary]
         if self._writeColour and lv.visOptions:

--- a/src/pyg4ometry/gdml/Writer.py
+++ b/src/pyg4ometry/gdml/Writer.py
@@ -387,7 +387,7 @@ option, physicsList="em";
                 aux = list(*lv.auxiliary)
             else:
                 aux = [lv.auxiliary]
-        if self._writeColour:
+        if self._writeColour and lv.visOptions:
             cAux = VisOptionsToAuxiliary(lv.visOptions)
             aux.append(cAux)
         for aux in lv.auxiliary:

--- a/src/pyg4ometry/geant4/LogicalVolume.py
+++ b/src/pyg4ometry/geant4/LogicalVolume.py
@@ -108,7 +108,7 @@ class LogicalVolume:
         self.registry = registry
 
         # physical visualisation options
-        self.visOptions = _VisOptions()
+        self.visOptions = kwargs.get("visOptions", None)
 
         # efficient overlap checking
         self.overlapChecked = False

--- a/src/pyg4ometry/geant4/LogicalVolume.py
+++ b/src/pyg4ometry/geant4/LogicalVolume.py
@@ -865,12 +865,13 @@ class LogicalVolume:
         """
         # if auxiliary is not None and not isinstance(auxiliary, _Auxiliary):
         #    raise ValueError("Auxiliary information must be a gdml.Defines.Auxiliary instance.")
+        if auxiliary == None:
+            return
         if isinstance(auxiliary, list) or isinstance(auxiliary, tuple):
             for aux in auxiliary:
                 self.addAuxiliaryInfo(aux)
         else:
-            if auxiliary:
-                self.auxiliary.append(auxiliary)
+            self.auxiliary.append(auxiliary)
 
     def extent(self, includeBoundingSolid=False):
         """

--- a/src/pyg4ometry/geant4/LogicalVolume.py
+++ b/src/pyg4ometry/geant4/LogicalVolume.py
@@ -62,6 +62,8 @@ class LogicalVolume:
     :param addRegistry:
     :type addRegistry: bool
 
+    Acceptable kwargs: "auxiliary", "visOptions".
+
     """
 
     def __init__(self, solid, material, name, registry=None, addRegistry=True, **kwargs):

--- a/src/pyg4ometry/geant4/LogicalVolume.py
+++ b/src/pyg4ometry/geant4/LogicalVolume.py
@@ -857,9 +857,9 @@ class LogicalVolume:
 
     def addAuxiliaryInfo(self, auxiliary):
         """
-        Add auxilary information to logical volume
+        Add auxiliary information to logical volume
         :param auxiliary: auxiliary information for the logical volume
-        :type auxiliary: tuple or list
+        :type auxiliary: pyg4ometry.gdml.Defines.Auxiliary, list(pyg4ometry.gdml.Defines.Auxiliary), tuple(pyg4ometry.gdml.Defines.Auxiliary)
         """
         # if auxiliary is not None and not isinstance(auxiliary, _Auxiliary):
         #    raise ValueError("Auxiliary information must be a gdml.Defines.Auxiliary instance.")

--- a/src/pyg4ometry/visualisation/UsdViewer.py
+++ b/src/pyg4ometry/visualisation/UsdViewer.py
@@ -65,8 +65,8 @@ def visOptions2MaterialPrim(stage, visOptions, materialPrim):
 
 
 class UsdViewer(_ViewerHierarchyBase):
-
     def __init__(self, filePath="./test.usd"):
+        super().__init__()
         if Usd is None:
             msg = "Failed to import open usd"
             raise RuntimeError(msg)
@@ -119,7 +119,8 @@ class UsdViewer(_ViewerHierarchyBase):
                 self.stage, self.materialRootPath + "/" + volume.name + "_mat"
             )
 
-            visOptions2MaterialPrim(self.stage, volume.visOptions, materialPrim)
+            vo = self.getVisOptionsLV(volume)
+            visOptions2MaterialPrim(self.stage, vo, materialPrim)
             UsdShade.MaterialBindingAPI(meshPrim).Bind(materialPrim)
 
             # loop over all daughters

--- a/src/pyg4ometry/visualisation/ViewerBase.py
+++ b/src/pyg4ometry/visualisation/ViewerBase.py
@@ -73,7 +73,7 @@ class ViewerBase:
         if self.materialVisOptions:
             # if 0x is in name, strip the appended pointer (common in exported GDML)
             if "0x" in materialName:
-                materialName = materialName[0: materialName.find("0x")]
+                materialName = materialName[0 : materialName.find("0x")]
             # get with default
             materialVis = v = self.materialVisOptions.get(materialName, self.defaultVisOptions)
         return materialVis
@@ -84,7 +84,12 @@ class ViewerBase:
         """
         materialVis = self._getMaterialVis(pv.logicalVolume.material.name)
         # take the first non-None set of visOptions
-        orderOfPrecedence = [pv.visOptions, pv.logicalVolume.visOptions, materialVis, self.defaultVisOptions]
+        orderOfPrecedence = [
+            pv.visOptions,
+            pv.logicalVolume.visOptions,
+            materialVis,
+            self.defaultVisOptions,
+        ]
         return next(item for item in orderOfPrecedence if item is not None)
 
     def getVisOptionsLV(self, lv):

--- a/src/pyg4ometry/visualisation/ViewerBase.py
+++ b/src/pyg4ometry/visualisation/ViewerBase.py
@@ -1,4 +1,5 @@
 import base64 as _base64
+import copy as _copy
 import numpy as _np
 import random as _random
 from .. import pycgal as _pycgal
@@ -47,7 +48,7 @@ class ViewerBase:
         self.bSubtractDaughters = False
 
         # default vis options
-        self.defaultVisOptions = None
+        self.defaultVisOptions = _VisOptions()
         self.defaultOverlapVisOptions = None
         self.defaultCoplanarVisOptions = None
         self.defaultProtusionVisOptions = None
@@ -65,6 +66,35 @@ class ViewerBase:
         self.instancePlacements = {}  # instance placements
         self.instanceVisOptions = {}  # instance vis options
         self.instancePbrOptions = {}  # instance pbr options
+
+    def _getMaterialVis(self, materialName):
+        materialVis = None
+        # a dict evaluates to True if not empty
+        if self.materialVisOptions:
+            # if 0x is in name, strip the appended pointer (common in exported GDML)
+            if "0x" in materialName:
+                materialName = materialName[0: materialName.find("0x")]
+            # get with default
+            materialVis = v = self.materialVisOptions.get(materialName, self.defaultVisOptions)
+        return materialVis
+
+    def getVisOptions(self, pv):
+        """
+        Return a set of vis options according to the precedence of pv, lv, material, default.
+        """
+        materialVis = self._getMaterialVis(pv.logicalVolume.material.name)
+        # take the first non-None set of visOptions
+        orderOfPrecedence = [pv.visOptions, pv.logicalVolume.visOptions, materialVis, self.defaultVisOptions]
+        return next(item for item in orderOfPrecedence if item is not None)
+
+    def getVisOptionsLV(self, lv):
+        """
+        Return a set of vis options according to the precedence of pv, lv, material, default.
+        """
+        materialVis = self._getMaterialVis(lv.material.name)
+        # take the first non-None set of visOptions
+        orderOfPrecedence = [lv.visOptions, materialVis, self.defaultVisOptions]
+        return next(item for item in orderOfPrecedence if item is not None)
 
     def setSubtractDaughters(self, subtractDaughters=True):
         self.bSubtractDaughters = subtractDaughters
@@ -111,20 +141,8 @@ class ViewerBase:
                 name = "world"
             self.addInstance(lv.name, mtra, tra, name)
 
-            materialName = lv.material.name
-
-            pointerLoc = materialName.find("0x")
-            if pointerLoc != -1:
-                materialName = materialName[0 : materialName.find("0x")]
-
-            # add vis options
-            if materialName in self.materialVisOptions:
-                visOptions = self.materialVisOptions[materialName]
-                visOptions.depth = depth
-                self.addVisOptions(lv.name, visOptions)
-            else:
-                visOptions.depth = depth
-                self.addVisOptions(lv.name, visOptions)
+            vo = self.getVisOptionsLV(lv)
+            self.addVisOptions(lv.name, vo)
 
             # add overlap meshes
             for [overlapmesh, overlaptype], i in zip(
@@ -145,6 +163,7 @@ class ViewerBase:
             print("Unknown logical volume type or null mesh")
 
         for pv in lv.daughterVolumes:
+            vo = self.getVisOptions(pv)
             if pv.type == "placement":
                 # pv transform
                 pvmrot = _np.linalg.inv(_transformation.tbxyz2matrix(pv.rotation.eval()))
@@ -159,12 +178,6 @@ class ViewerBase:
                 mtra_new = mtra @ pvmrot @ pvmsca
                 tra_new = mtra @ pvtra + tra
 
-                if not pv.visOptions:
-                    vo = pv.logicalVolume.visOptions
-                else:
-                    vo = pv.visOptions
-
-                # pv.visOptions.colour = [_random.random(), _random.random(), _random.random()]
                 self.addLogicalVolume(
                     pv.logicalVolume,
                     mtra_new,
@@ -183,11 +196,12 @@ class ViewerBase:
                     new_mtra = mtra @ pvmrot
                     new_tra = mtra @ pvtra + tra
 
-                    pv.visOptions.depth = depth + 2
+                    vo2 = _copy.deepcopy(vo)
+                    vo2.depth += 1
 
                     self.addMesh(pv.name, mesh.localmesh)
                     self.addInstance(pv.name, new_mtra, new_tra, pv.name)
-                    self.addVisOptions(pv.name, pv.visOptions)
+                    self.addVisOptions(pv.name, vo2)
             elif pv.type == "parametrised":
                 for mesh, trans, i in zip(pv.meshes, pv.transforms, range(0, len(pv.meshes), 1)):
                     pv_name = pv.name + "_param_" + str(i)
@@ -200,11 +214,12 @@ class ViewerBase:
                     new_mtra = mtra @ pvmrot
                     new_tra = mtra @ pvtra + tra
 
-                    pv.visOptions.depth = depth + 2
+                    vo2 = _copy.deepcopy(vo)
+                    vo2.depth += 1
 
                     self.addMesh(pv_name, mesh.localmesh)
                     self.addInstance(pv_name, new_mtra, new_tra, pv_name)
-                    self.addVisOptions(pv_name, pv.visOptions)
+                    self.addVisOptions(pv_name, vo2)
 
     def addFlukaRegions(self, fluka_registry, max_region=1000000, debugIO=False):
         icount = 0

--- a/src/pyg4ometry/visualisation/ViewerHierarchyBase.py
+++ b/src/pyg4ometry/visualisation/ViewerHierarchyBase.py
@@ -1,10 +1,12 @@
+from . import VisualisationOptions as _VisOptions
+
 class ViewerHierarchyBase:
     """
     Base class for all viewers and exporters. Handles unique meshes and their instances
     """
 
     def __init__(self):
-        pass
+        self.defaultVisOptions = _VisOptions()
 
     def addWorld(self, worldLV):
         self.worldLV = worldLV
@@ -17,3 +19,19 @@ class ViewerHierarchyBase:
 
         for daughter in LV.daughterVolumes:
             self.traverseHierarchy(daughter.logicalVolume)
+
+    def getVisOptions(self, pv):
+        """
+        Return a set of vis options according to the precedence of pv, lv, default.
+        """
+        # take the first non-None set of visOptions
+        orderOfPrecedence = [pv.visOptions, pv.logicalVolume.visOptions, self.defaultVisOptions]
+        return next(item for item in orderOfPrecedence if item is not None)
+
+    def getVisOptionsLV(self, lv):
+        """
+        Return a set of vis options according to the precedence of lv, default.
+        """
+        # take the first non-None set of visOptions
+        orderOfPrecedence = [lv.visOptions, self.defaultVisOptions]
+        return next(item for item in orderOfPrecedence if item is not None)

--- a/src/pyg4ometry/visualisation/ViewerHierarchyBase.py
+++ b/src/pyg4ometry/visualisation/ViewerHierarchyBase.py
@@ -1,5 +1,6 @@
 from . import VisualisationOptions as _VisOptions
 
+
 class ViewerHierarchyBase:
     """
     Base class for all viewers and exporters. Handles unique meshes and their instances

--- a/src/pyg4ometry/visualisation/VisualisationOptions.py
+++ b/src/pyg4ometry/visualisation/VisualisationOptions.py
@@ -64,6 +64,10 @@ class VisualisationOptions:
             f"vis={self.visible}, linewidth={self.lineWidth}, depth={self.depth}>"
         )
 
+    def getBDSIMVRGBA(self):
+        c = self.colour
+        return f"{int(self.visible)} {c[0]} {c[1]} {c[2]} {self.alpha}"
+
     def getColour(self):
         """
         Return the colour and generate a random colour if flagged.

--- a/src/pyg4ometry/visualisation/VtkViewer.py
+++ b/src/pyg4ometry/visualisation/VtkViewer.py
@@ -1113,18 +1113,23 @@ class VtkViewer:
 class VtkViewerColoured(VtkViewer):
     """
     Visualiser that extends VtkViewer. Uses "flat" interpolation and introduces control over colours.
+    Already existing visOptions in logical volumes and physics volumes are first respected.
 
     :Keyword Arguments:
-    * **materialVisOptions**: {"materialName": :class:`VisualisationOptions` or list or tuple, ...}
-    * **interpolation** (str): see :class:`VtkViewer`
-    * **defaultColour** (str): "random" or [r,g,b]
+    :param materialVisOptions: {"materialName": :class:`VisualisationOptions` or list or tuple, ...}
+    :param interpolation: see :class:`VtkViewer`
+    :type interpolation: str
+    :param defaultColour: "random" or [r,g,b]
+    :type defaultColour: str, list(float, float, float)
+    :param defaultAlpha: default alpha (0 to 1) for any volume
+    :type defaultAlpha: float, int
 
     :Examples:
 
     >>> vMaterialMap = VtkViewerColoured(materialVisOptions={"G4_WATER":[0,0,1]})
     >>> vRandom = VtkViewerColoured(defaultColour="random")
     >>> vColoured = VtkViewerColoured(defaultColour=[0.1,0.1,0.1])
-    >>> vColourAlpha = VtkViewerColoured(defaultColour=[0.1,0.1,0.1,0.5])
+    >>> vColourAlpha = VtkViewerColoured(defaultColour=[0.1,0.1,0.1], defaultAlpha=0.2)
 
     of use visualisation options instances
 

--- a/src/pyg4ometry/visualisation/VtkViewer.py
+++ b/src/pyg4ometry/visualisation/VtkViewer.py
@@ -1098,7 +1098,12 @@ class VtkViewer:
             materialVis = v = self.materialVisOptions.get(materialName, self._defaultVis)
 
         # take the first non-None set of visOptions
-        orderOfPrecedence = [pv.visOptions, pv.logicalVolume.visOptions, materialVis, self._defaultVis]
+        orderOfPrecedence = [
+            pv.visOptions,
+            pv.logicalVolume.visOptions,
+            materialVis,
+            self._defaultVis,
+        ]
 
         return next(item for item in orderOfPrecedence if item is not None)
 
@@ -1143,7 +1148,9 @@ class VtkViewerColoured(VtkViewer):
     to a :class:`VisualisationOptions` instance.
     """
 
-    def __init__(self, *args, defaultColour=None, defaultAlpha=0.5, materialVisOptions=None, **kwargs):
+    def __init__(
+        self, *args, defaultColour=None, defaultAlpha=0.5, materialVisOptions=None, **kwargs
+    ):
         kwargs["interpolation"] = kwargs.get("interpolation", "flat")
         super().__init__(*args, **kwargs)
         self.materialVisOptions = {}
@@ -1168,7 +1175,6 @@ class VtkViewerColoured(VtkViewer):
                     self.materialVisOptions[k] = vi
                 else:
                     self.materialVisOptions[k] = v
-
 
 
 # for backwards compatibility for old name

--- a/src/pyg4ometry/visualisation/VtkViewer.py
+++ b/src/pyg4ometry/visualisation/VtkViewer.py
@@ -566,6 +566,7 @@ class VtkViewer:
                     f"VtkViewer.addLogicalVolume> Daughter {pv.name} {pv.logicalVolume.name} {pv.logicalVolume.solid.name} "
                 )
 
+            visOptions = self.getVisOptions(pv)
             if pv.type == "placement":
                 # pv transform
                 pvmrot = _np.linalg.inv(_transformation.tbxyz2matrix(pv.rotation.eval()))
@@ -580,7 +581,6 @@ class VtkViewer:
                 new_tra = mtra @ pvtra + tra
 
                 if pv.logicalVolume.type != "assembly" and pv.logicalVolume.mesh is not None:
-                    visOptions = self.getVisOptions(pv)
                     if visOptions.visible:
                         mesh = (
                             pv.logicalVolume.mesh.localmesh
@@ -607,7 +607,7 @@ class VtkViewer:
                         pv.logicalVolume.mesh.overlapmeshes,
                         range(len(pv.logicalVolume.mesh.overlapmeshes)),
                     ):
-                        visOptions = self.getOverlapVisOptions(overlaptype)
+                        visOptionsOverlap = self.getOverlapVisOptions(overlaptype)
 
                         self.addMesh(
                             pv_name,
@@ -621,64 +621,64 @@ class VtkViewer:
                             self.physicalMapperMapOverlap,
                             self.actorsOverlap,
                             self.physicalActorMapOverlap,
-                            visOptions=visOptions,
+                            visOptions=visOptionsOverlap,
                             overlap=True,
                         )
 
                 self.addLogicalVolumeRecursive(pv.logicalVolume, new_mtra, new_tra)
 
             elif pv.type == "replica" or pv.type == "division":
-                for mesh, trans in zip(pv.meshes, pv.transforms):
-                    # pv transform
-                    pvmrot = _transformation.tbxyz2matrix(trans[0])
-                    pvtra = _np.array(trans[1])
+                if visOptions.visible:
+                    for mesh, trans in zip(pv.meshes, pv.transforms):
+                        # pv transform
+                        pvmrot = _transformation.tbxyz2matrix(trans[0])
+                        pvtra = _np.array(trans[1])
 
-                    # pv compound transform
-                    new_mtra = mtra @ pvmrot
-                    new_tra = mtra @ pvtra + tra
+                        # pv compound transform
+                        new_mtra = mtra @ pvmrot
+                        new_tra = mtra @ pvtra + tra
 
-                    # TBC - should pv.visOptions be used exclusively?
-                    self.addMesh(
-                        pv_name,
-                        mesh.solid.name,
-                        mesh.localmesh,
-                        new_mtra,
-                        new_tra,
-                        self.localmeshes,
-                        self.filters,
-                        self.mappers,
-                        self.physicalMapperMap,
-                        self.actors,
-                        self.physicalActorMap,
-                        visOptions=pv.logicalVolume.visOptions,
-                        overlap=False,
-                    )
+                        self.addMesh(
+                            pv_name,
+                            mesh.solid.name,
+                            mesh.localmesh,
+                            new_mtra,
+                            new_tra,
+                            self.localmeshes,
+                            self.filters,
+                            self.mappers,
+                            self.physicalMapperMap,
+                            self.actors,
+                            self.physicalActorMap,
+                            visOptions=visOptions,
+                            overlap=False,
+                        )
             elif pv.type == "parametrised":
-                for mesh, trans in zip(pv.meshes, pv.transforms):
-                    # pv transform
-                    pvmrot = _transformation.tbxyz2matrix(trans[0].eval())
-                    pvtra = _np.array(trans[1].eval())
+                if visOptions.visible:
+                    for mesh, trans in zip(pv.meshes, pv.transforms):
+                        # pv transform
+                        pvmrot = _transformation.tbxyz2matrix(trans[0].eval())
+                        pvtra = _np.array(trans[1].eval())
 
-                    # pv compound transform
-                    new_mtra = mtra @ pvmrot
-                    new_tra = mtra @ pvtra + tra
+                        # pv compound transform
+                        new_mtra = mtra @ pvmrot
+                        new_tra = mtra @ pvtra + tra
 
-                    # TBC - should pv.visOptions be used exclusively?
-                    self.addMesh(
-                        pv_name,
-                        mesh.solid.name,
-                        mesh.localmesh,
-                        new_mtra,
-                        new_tra,
-                        self.localmeshes,
-                        self.filters,
-                        self.mappers,
-                        self.physicalMapperMap,
-                        self.actors,
-                        self.physicalActorMap,
-                        visOptions=pv.logicalVolume.visOptions,
-                        overlap=False,
-                    )
+                        self.addMesh(
+                            pv_name,
+                            mesh.solid.name,
+                            mesh.localmesh,
+                            new_mtra,
+                            new_tra,
+                            self.localmeshes,
+                            self.filters,
+                            self.mappers,
+                            self.physicalMapperMap,
+                            self.actors,
+                            self.physicalActorMap,
+                            visOptions=visOptions,
+                            overlap=False,
+                        )
 
     def addMesh(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,5 +35,5 @@ def pytest_sessionfinish(session, exitstatus):
 @pytest.fixture(scope="session")
 def testdata():
     g4data = G4EdgeTestData()
-    g4data.checkout("8bc13ee")
+    g4data.checkout("8b399fd")
     return g4data

--- a/tests/gdml/test_Reader.py
+++ b/tests/gdml/test_Reader.py
@@ -934,16 +934,16 @@ def test_GdmlLoad_Par02FullDetector(testdata):
 
 def test_GdmlLoad_BDSIM_colour(testdata):
     registry, writtenFilename = pyg4ometryLoadWriteTest(
-        #testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
+        # testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
         "/Users/lnevay/physics/reps/bdsim-gdml-colour-writing-build/examples/features/geometry/4_magnets/vkickers-coloured.gdml"
     )
 
+
 def test_GdmlLoad_BDSIM_colour_force_visible(testdata):
-    #fn = testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
+    # fn = testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
     fn = "/Users/lnevay/physics/reps/bdsim-gdml-colour-writing-build/examples/features/geometry/4_magnets/vkickers-coloured.gdml"
     filepath = _pj(fn)
 
     reader = pyg4ometry.gdml.Reader(filepath, makeAllVisible=True)
     wlv = reader.getRegistry().getWorldVolume()
     assert wlv.daughterVolumes[0].logicalVolume.visible
-

--- a/tests/gdml/test_Reader.py
+++ b/tests/gdml/test_Reader.py
@@ -943,4 +943,4 @@ def test_GdmlLoad_BDSIM_colour_force_visible(testdata):
 
     reader = pyg4ometry.gdml.Reader(filepath, makeAllVisible=True)
     wlv = reader.getRegistry().getWorldVolume()
-    assert wlv.daughterVolumes[0].logicalVolume.visible
+    assert wlv.daughterVolumes[0].logicalVolume.visOptions.visible

--- a/tests/gdml/test_Reader.py
+++ b/tests/gdml/test_Reader.py
@@ -930,3 +930,20 @@ def test_GdmlLoad_Par02FullDetector(testdata):
         testdata["gdml/Par02/Par02FullDetector.gdml"]
     )
     # assert(geant4LoadTest(writtenFilename)) # Overlaps in the orignal file
+
+
+def test_GdmlLoad_BDSIM_colour(testdata):
+    registry, writtenFilename = pyg4ometryLoadWriteTest(
+        #testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
+        "/Users/lnevay/physics/reps/bdsim-gdml-colour-writing-build/examples/features/geometry/4_magnets/vkickers-coloured.gdml"
+    )
+
+def test_GdmlLoad_BDSIM_colour_force_visible(testdata):
+    #fn = testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
+    fn = "/Users/lnevay/physics/reps/bdsim-gdml-colour-writing-build/examples/features/geometry/4_magnets/vkickers-coloured.gdml"
+    filepath = _pj(fn)
+
+    reader = pyg4ometry.gdml.Reader(filepath, makeAllVisible=True)
+    wlv = reader.getRegistry().getWorldVolume()
+    assert wlv.daughterVolumes[0].logicalVolume.visible
+

--- a/tests/gdml/test_Reader.py
+++ b/tests/gdml/test_Reader.py
@@ -934,15 +934,12 @@ def test_GdmlLoad_Par02FullDetector(testdata):
 
 def test_GdmlLoad_BDSIM_colour(testdata):
     registry, writtenFilename = pyg4ometryLoadWriteTest(
-        # testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
-        "/Users/lnevay/physics/reps/bdsim-gdml-colour-writing-build/examples/features/geometry/4_magnets/vkickers-coloured.gdml"
+        testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
     )
 
 
 def test_GdmlLoad_BDSIM_colour_force_visible(testdata):
-    # fn = testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"]
-    fn = "/Users/lnevay/physics/reps/bdsim-gdml-colour-writing-build/examples/features/geometry/4_magnets/vkickers-coloured.gdml"
-    filepath = _pj(fn)
+    filepath = _pj(testdata["gdml/CompoundExamples/bdsim/vkickers-coloured.gdml"])
 
     reader = pyg4ometry.gdml.Reader(filepath, makeAllVisible=True)
     wlv = reader.getRegistry().getWorldVolume()

--- a/tests/geant4/test_lhc_blm_model.py
+++ b/tests/geant4/test_lhc_blm_model.py
@@ -36,8 +36,8 @@ materialToColour = {
 def assign_colour(lv, colour):
     colour_val = COLOURS.get(colour, (128, 128, 128, 1))
     colour_norm = [v / 255.0 for v in colour_val[:3]] + [colour_val[3]]
-    col_string = "{} {} {} {}".format(*colour_norm)
-    aux_tag = _gd.Auxiliary("colour", col_string, registry=lv.registry)
+    col_string = "1 {} {} {} {}".format(*colour_norm)
+    aux_tag = _gd.Auxiliary("bds_vrgba", col_string, registry=lv.registry)
     lv.addAuxiliaryInfo(aux_tag)
 
 


### PR DESCRIPTION
Relatively simple addition to read aux tags in GDML for visualisation options.

Change of LogicalVolume to have no VisOptions instance by default (like PV). Defaults are enforced in the visualiser(s). This is an easier way to tell if one has been explicitly given, or default to materials, or default to supplied grey default. Works as previously expected, but loaded colours take precedence.

This will require the pull request from the test data to be accepted first. See: [https://github.com/g4edge/testdata/pull/32](https://github.com/g4edge/testdata/pull/32)

Only with that, can I update the reference SHA1 commit ID here to use the new test file. 

GDML with colour can be exported now from BDSIM with once that [pull request](https://github.com/bdsim-collaboration/bdsim/pull/33) is also merged.