### PR TITLE
remove `print()` statements and fix logging usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ lint.extend-ignore = [
   "E501",   # Line too long
   "PT004",  # Use underscore for non-returning fixture (use usefixture instead)
   "RUF012", # Mutable class attributes should be annotated with typing.ClassVar
+  "RUF100", # unused noqa TODO: remove after print() migration
 ]
 src = ["src"]
 lint.unfixable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,12 +123,12 @@ lint.select = [
   "EXE",         # flake8-executable
   "NPY",         # NumPy specific rules
   # "PD",          # pandas-vet
+  "T201",
 ]
 
 lint.extend-ignore = [
   "PLR",    # Design related pylint codes
   "E501",   # Line too long
-  "PT004",  # Use underscore for non-returning fixture (use usefixture instead)
   "RUF012", # Mutable class attributes should be annotated with typing.ClassVar
   "RUF100", # unused noqa TODO: remove after print() migration
 ]
@@ -147,6 +147,10 @@ lint.isort.required-imports = ["from __future__ import annotations"]
 "src/pyg4ometry/misc/TestUtils.py" = ["T201"]
 "src/pyg4ometry/compare/_Compare.py" = ["T201"]
 # further ignores, TODO: should be removed.
+"src/pyg4ometry/gui/**" = ["T201"]
+"src/pyg4ometry/{fluka,convert}/**" = ["T201"]
+"src/pyg4ometry/{io,analysis,features}/**" = ["T201"]
+"src/pyg4ometry/{freecad,pycgal,pyoce}/**" = ["T201"]
 "src/pyg4ometry/visualisation/{UsdViewer,ViewerHierarchyBase}.py" = ["T201"]
 
 [tool.cibuildwheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,12 @@ lint.flake8-unused-arguments.ignore-variadic-names = true
 lint.isort.required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
+# ignores because of tests.
 "tests/**" = ["T20"]
+"src/pyg4ometry/misc/TestUtils.py" = ["T201"]
+"src/pyg4ometry/compare/_Compare.py" = ["T201"]
+# further ignores, TODO: should be removed.
+"src/pyg4ometry/visualisation/{UsdViewer,ViewerHierarchyBase}.py" = ["T201"]
 
 [tool.cibuildwheel]
 build = ["*macosx*", "*manylinux_x86_64", "*windows*"]

--- a/src/pyg4ometry/__init__.py
+++ b/src/pyg4ometry/__init__.py
@@ -5,6 +5,10 @@ except ImportError:
     __version__ = "unknown version"
     version_tuple = (0, 0, "unknown version")
 
+import logging
+
+_log = logging.getLogger(__name__)
+
 from . import config
 from . import compare
 from . import convert
@@ -19,7 +23,7 @@ from . import pycgal
 try:
     from . import pyoce
 except ImportError:
-    print("Failed to import open cascade")
+    _log.error("Failed to import opencascade")
 from . import stl
 from . import transformation
 from . import visualisation
@@ -29,8 +33,4 @@ from . import cli
 from . import misc
 from . import analysis
 from . import montecarlo
-
-try:
-    from . import usd
-except ImportError:
-    print("Failed to import open usd")
+from . import usd

--- a/src/pyg4ometry/analysis/flukaData.py
+++ b/src/pyg4ometry/analysis/flukaData.py
@@ -38,10 +38,10 @@ def debugDumpFile(fd, limit=10000000):
     while data:
         data = fortran_read(fd)
         if data and iData < limit:
-            print(iData, len(data))
+            print(iData, len(data))  # noqa: T201
         iData += 1
 
-    print("total records", iData)
+    print("total records", iData)  # noqa: T201
 
 
 class _FlukaDataFile:
@@ -84,11 +84,11 @@ class _FlukaDataFile:
         pass
 
     def print_header(self):
-        print("title  : ", self.title)
-        print("time   : ", self.time)
-        print("weight : ", self.weight)
-        print("ncase  : ", self.ncase)
-        print("nbatch : ", self.nbatch)
+        print("title  : ", self.title)  # noqa: T201
+        print("time   : ", self.time)  # noqa: T201
+        print("weight : ", self.weight)  # noqa: T201
+        print("ncase  : ", self.ncase)  # noqa: T201
+        print("nbatch : ", self.nbatch)  # noqa: T201
 
 
 class FlukaBinData:

--- a/src/pyg4ometry/cli.py
+++ b/src/pyg4ometry/cli.py
@@ -130,7 +130,7 @@ def _parseStrPythonAsDict(strPython):
 
 
 def _printCitation():
-    print("https://zenodo.org/doi/10.5281/zenodo.10449301")
+    print("https://zenodo.org/doi/10.5281/zenodo.10449301")  # noqa: T201
 
 
 def cli(
@@ -159,11 +159,11 @@ def cli(
     verbose=None,
     testing=False,
 ):
-    print("pyg4 - command line interface")
+    print("pyg4 - command line interface")  # noqa: T201
 
     # switch on file type
     if not inputFileName:
-        print("pyg4> need input file name")
+        print("pyg4> need input file name")  # noqa: T201
 
     try:
         if str(inputFileName).startswith("g4edgetestdata/"):
@@ -173,7 +173,7 @@ def cli(
                 d = g4edgetestdata.G4EdgeTestData()
                 inputFileName = d[inputFileName.replace("g4edgetestdata/", "")]
             except ImportError:
-                print("pyg4> g4edgetestdata package not available - install with pip")
+                print("pyg4> g4edgetestdata package not available - install with pip")  # noqa: T201
         f = open(inputFileName)
         f.close()
     except FileNotFoundError:
@@ -189,9 +189,9 @@ def cli(
         bbExtent = _np.array(wl.extent())
         bbDExtent = bbExtent[1] - bbExtent[0]
         bbCentre = bbExtent[0] + bbExtent[1]
-        print("pyg4> extent        ", bbExtent)
-        print("pyg4> extent size   ", bbDExtent)
-        print("pyg4> extent centre ", bbCentre)
+        print("pyg4> extent        ", bbExtent)  # noqa: T201
+        print("pyg4> extent size   ", bbDExtent)  # noqa: T201
+        print("pyg4> extent centre ", bbCentre)  # noqa: T201
 
     # these are not used on their own but possibly as part of other commands in multiple places
     r = rotation if rotation else [0, 0, 0]
@@ -199,47 +199,47 @@ def cli(
 
     if info:
         if info == "reg":
-            print("pyg4> registry defines")
-            print(list(reg.defineDict.keys()))
-            print("pyg4> registry materials")
-            print(list(reg.materialDict.keys()))
-            print("pyg4> registry solids")
-            print(list(reg.solidDict.keys()))
-            print("pyg4> registry logical volumes")
-            print(list(reg.logicalVolumeDict.keys()))
-            print("pyg4> registry assembly volumes")
-            print(list(reg.assemblyVolumeDict.keys()))
-            print("pyg4> registry physical volumes")
-            print(list(reg.physicalVolumeDict.keys()))
-            print("pyg4> registry optical surfaces")
-            print(list(reg.surfaceDict.keys()))
+            print("pyg4> registry defines")  # noqa: T201
+            print(list(reg.defineDict.keys()))  # noqa: T201
+            print("pyg4> registry materials")  # noqa: T201
+            print(list(reg.materialDict.keys()))  # noqa: T201
+            print("pyg4> registry solids")  # noqa: T201
+            print(list(reg.solidDict.keys()))  # noqa: T201
+            print("pyg4> registry logical volumes")  # noqa: T201
+            print(list(reg.logicalVolumeDict.keys()))  # noqa: T201
+            print("pyg4> registry assembly volumes")  # noqa: T201
+            print(list(reg.assemblyVolumeDict.keys()))  # noqa: T201
+            print("pyg4> registry physical volumes")  # noqa: T201
+            print(list(reg.physicalVolumeDict.keys()))  # noqa: T201
+            print("pyg4> registry optical surfaces")  # noqa: T201
+            print(list(reg.surfaceDict.keys()))  # noqa: T201
         elif info == "tree":
             _pyg4.geant4.DumpGeometryStructureTree(wl, 0)
         elif info == "instances":
-            print("pyg4> Not yet implemented")
+            print("pyg4> Not yet implemented")  # noqa: T201
         else:
             errMsg = "Accepted info keys are 'reg', 'tree', 'instances'"
             raise ValueError(errMsg)
 
     if checkOverlaps:
-        print("pyg4> checkoverlaps")
+        print("pyg4> checkoverlaps")  # noqa: T201
         wl.checkOverlaps(True)
 
     if analysis:
-        print("pyg4> analysis")
+        print("pyg4> analysis")  # noqa: T201
         a = _pyg4.geant4.AnalyseGeometryComplexity(reg.getWorldVolume())
         a.printSummary()
 
     if compareFileName is not None:
         creg, cwl = _loadFile(compareFileName)
         comparision = _pyg4.compare.geometry(wl, cwl, _pyg4.compare.Tests(), False)
-        print("pyg4> compare")
+        print("pyg4> compare")  # noqa: T201
         comparision.print()
 
     if appendFileName is not None:
         reg1, wl1 = _loadFile(appendFileName)
         wp1 = _pyg4.geant4.PhysicalVolume(r, t, wl1, "l1_pv", wl, reg)
-        print("pyg4> append")
+        print("pyg4> append")  # noqa: T201
         reg.addVolumeRecursive(wp1)
 
     # extract lv in new registry etc
@@ -324,7 +324,7 @@ def cli(
         v.addCutter("cli-cutter", o, n)
         v.buildPipelinesAppend()
         v.exportCutter("cli-cutter", planeCutterOutputFileName)
-        print(
+        print(  # noqa: T201
             "pyg4> cutter with " + str(o) + ", " + str(n) + " written to: ",
             planeCutterOutputFileName,
         )
@@ -340,7 +340,7 @@ def mainNoExceptions(testArgs=None, testing=False):
     try:
         main(testArgs, testing)
     except Exception as ex:
-        print(*ex.args)
+        print(*ex.args)  # noqa: T201
         exit(1)
 
 
@@ -500,8 +500,8 @@ def main(testArgs=None, testing=False):
 
     verbose = options.__dict__["verbose"]
     if verbose:
-        print("pyg4> options")
-        print(options)
+        print("pyg4> options")  # noqa: T201
+        print(options)  # noqa: T201
 
     if options.__dict__["citation"]:
         _printCitation()
@@ -509,7 +509,7 @@ def main(testArgs=None, testing=False):
 
     # absolutely need a file name
     if options.__dict__["inputFileName"] is None:
-        print("pyg4> need an input file")
+        print("pyg4> need an input file")  # noqa: T201
         exit(1)
 
     # parse plane
@@ -517,28 +517,28 @@ def main(testArgs=None, testing=False):
     if planeData is not None:
         planeData = _parseStrMultipletAsFloat(planeData)
         if verbose:
-            print("pyg4> clipper plane data", planeData)
+            print("pyg4> clipper plane data", planeData)  # noqa: T201
 
     # parse translation
     translation = options.__dict__["translation"]
     if translation is not None:
         translation = _parseStrMultipletAsFloat(translation)
         if verbose:
-            print("pyg4> translation ", translation)
+            print("pyg4> translation ", translation)  # noqa: T201
 
     # parse rotation
     rotation = options.__dict__["rotation"]
     if rotation is not None:
         rotation = _parseStrMultipletAsFloat(rotation)
         if verbose:
-            print("pyg4> rotation ", rotation)
+            print("pyg4> rotation ", rotation)  # noqa: T201
 
     # parse clip box
     clipbox = options.__dict__["clip"]
     if clipbox is not None:
         clipbox = _parseStrMultipletAsFloat(clipbox)
         if verbose:
-            print("pyg4> clip ", clipbox)
+            print("pyg4> clip ", clipbox)  # noqa: T201
 
     # parse solid
     # this must be done when we have a registry
@@ -552,7 +552,7 @@ def main(testArgs=None, testing=False):
     if featureData is not None:
         featureData = _parseStrMultipletAsFloat(featureData)
         if verbose:
-            print("pyg4> feature data", featureData)
+            print("pyg4> feature data", featureData)  # noqa: T201
 
     # parse gltf scale
     gltfScale = options.__dict__["gltfScale"]

--- a/src/pyg4ometry/compare/_Compare.py
+++ b/src/pyg4ometry/compare/_Compare.py
@@ -105,7 +105,7 @@ class Tests:
         Print all tests names - the exact strings that can be used to turn them off or on.
         """
         for name in cls._testNames:
-            print('"' + name + '"')
+            print('"' + name + '"')  # noqa: T201
 
     def __repr__(self):
         s = ""
@@ -238,22 +238,22 @@ class ComparisonResult:
         >>> cr.print(testResultsToPrint=TestResult.All())
         >>> cr.print(allTests=True)
         """
-        print("Overall result> ", self.result)
+        print("Overall result> ", self.result)  # noqa: T201
         if allTests:
             testResultsToPrint = TestResult.All()
         if testName is None:
             for tn, results in self.test.items():
-                print("Test> ", tn)
+                print("Test> ", tn)  # noqa: T201
                 for result in results:
                     # only print if required
                     if result.testResult in testResultsToPrint:
-                        print(result)
-                print(" ")
+                        print(result)  # noqa: T201
+                print(" ")  # noqa: T201
         else:
-            print("Test> ", testName)
+            print("Test> ", testName)  # noqa: T201
             for result in self.test[testName]:
-                print(result)
-            print(" ")  # for a new line
+                print(result)  # noqa: T201
+            print(" ")  # for a new line  # noqa: T201
 
 
 def gdmlFiles(referenceFile, otherFile, tests=Tests(), includeAllTestResults=False):

--- a/src/pyg4ometry/freecad/Reader.py
+++ b/src/pyg4ometry/freecad/Reader.py
@@ -13,6 +13,8 @@ from .. import transformation as _trans
 from ..geant4 import Material as _Material
 from ..meshutils import MeshShrink as _MeshShrink
 
+_log = _log.getLogger(__name__)
+
 
 class Reader:
     def __init__(self, fileName, registryOn=True, fileNameAux=None):
@@ -170,7 +172,7 @@ class Reader:
                         globalPlacement.Rotation = globalRotation.multiply(globalPlacement.Rotation)
 
                 # info log output
-                _log.info(
+                _log.debug(
                     f"freecad.reader.convertFlat> Part::Feature label={obj.Label} typeid={obj.TypeId} placement={obj.Placement}"
                 )
 
@@ -379,7 +381,7 @@ class Reader:
 
     def recursePrintObjectTree(self, obj):
         if obj.TypeId == "App::Part":
-            _log.info(
+            _log.debug(
                 f"freecad.Reader.recursePrintObjectTree> App::Part {obj.TypeId} {obj.Label} {obj.Placement}"
             )
             for gobj in obj.Group:
@@ -395,7 +397,7 @@ class Reader:
         import pyg4ometry.gdml.Defines
 
         if obj.TypeId == "App::Part":  # mapped to logical volume, group objects mapped to physical
-            _log.info(
+            _log.debug(
                 f"freecad.reader.recurseObjectTree> App::Part label={obj.Label} grouplen={len(obj.Group)} placement={obj.Placement}"
             )
 
@@ -451,7 +453,7 @@ class Reader:
 
             return objects
         elif obj.TypeId == "Part::Feature":  # mapped to logical volumes
-            _log.info(
+            _log.debug(
                 f"freecad.reader.recurseObjectTree> Part::Feature label={obj.Label} placement={obj.Placement}"
             )
 

--- a/src/pyg4ometry/gdml/Defines.py
+++ b/src/pyg4ometry/gdml/Defines.py
@@ -1,7 +1,10 @@
 import numbers as _numbers
 import numpy as _np
 import re as _re
+import logging as _log
 from . import Units as _Units
+
+_log = _log.getLogger(__name__)
 
 
 class BasicExpression:
@@ -182,7 +185,7 @@ def upgradeToVector(var, reg, type="position", unit="", addRegistry=False):
         elif type == "scale":
             return Scale("", var[0], var[1], var[2], "none", reg, addRegistry)
         else:
-            print("type not defined")
+            _log.warning(f"vector type {type} not defined")
 
 
 def upgradeToTransformation(var, reg, addRegistry=False):

--- a/src/pyg4ometry/gdml/GdmlExpression/GdmlExpressionEval.py
+++ b/src/pyg4ometry/gdml/GdmlExpression/GdmlExpressionEval.py
@@ -10,9 +10,6 @@ import math
 import numpy
 import builtins
 
-# from IPython import embed
-# import traceback
-
 
 class GdmlExpressionEvalVisitor(GdmlExpressionVisitor):
     def __init__(self):
@@ -37,7 +34,7 @@ class GdmlExpressionEvalVisitor(GdmlExpressionVisitor):
 
     def visitPrintExpr(self, ctx):
         value = self.visit(ctx.expr())
-        print(value)
+        print(value)  # noqa: T201
         return 0
 
     def visitScientific(self, ctx):
@@ -74,13 +71,11 @@ class GdmlExpressionEvalVisitor(GdmlExpressionVisitor):
         return base
 
     def visitMinExpression(self, ctx):
-        print(ctx.signedAtom(0), ctx.signedAtom(1))
         v1 = float(self.visit(ctx.signedAtom(0)))
         v2 = float(self.visit(ctx.signedAtom(1)))
         return min(v1, v2)
 
     def visitMaxExpression(self, ctx):
-        print(ctx.signedAtom(0), ctx.signedAtom(1))
         v1 = float(self.visit(ctx.signedAtom(0)))
         v2 = float(self.visit(ctx.signedAtom(1)))
         return max(v1, v2)

--- a/src/pyg4ometry/gdml/Writer.py
+++ b/src/pyg4ometry/gdml/Writer.py
@@ -6,6 +6,8 @@ from ..gdml import Defines as _Defines
 from .. import geant4 as _g4
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class Writer:
     """

--- a/src/pyg4ometry/geant4/AssemblyVolume.py
+++ b/src/pyg4ometry/geant4/AssemblyVolume.py
@@ -4,11 +4,12 @@ from . import solid as _solid
 from ..visualisation import Mesh as _Mesh
 from ..visualisation import VisualisationOptions as _VisOptions
 
-
 import numpy as _np
 import logging as _log
 from collections import defaultdict as _defaultdict
 import copy as _copy
+
+_log = _log.getLogger(__name__)
 
 
 class AssemblyVolume:
@@ -131,7 +132,9 @@ class AssemblyVolume:
         # cannot currently deal with replica, division and parametrised
         if pv.type != "placement":
             if warn:
-                print("Cannot generate specific daughter mesh for replica, division, parameterised")
+                _log.error(
+                    "Cannot generate specific daughter mesh for replica, division, parameterised"
+                )
             return None
         if pv.logicalVolume.type == "assembly":
             mesh = pv.logicalVolume.getAABBMesh()
@@ -259,7 +262,7 @@ class AssemblyVolume:
         return
 
     def extent(self, includeBoundingSolid=True):
-        _log.info(f"AssemblyVolume.extent> {self.name} ")
+        _log.debug(f"AssemblyVolume.extent> {self.name} ")
 
         vMin = [1e99, 1e99, 1e99]
         vMax = [-1e99, -1e99, -1e99]
@@ -346,8 +349,8 @@ class AssemblyVolume:
         return wl
 
     def dumpStructure(self, depth=0):
-        print(depth * "-" + self.name + " (lv)")
+        print(depth * "-" + self.name + " (lv)")  # noqa: T201
 
         for d in self.daughterVolumes:
-            print(2 * depth * "-" + d.name + " (pv)")
+            print(2 * depth * "-" + d.name + " (pv)")  # noqa: T201
             d.logicalVolume.dumpStructure(depth + 2)

--- a/src/pyg4ometry/geant4/DivisionVolume.py
+++ b/src/pyg4ometry/geant4/DivisionVolume.py
@@ -8,6 +8,8 @@ import numpy as _np
 import copy as _copy
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class DivisionVolume(_PhysicalVolume):
     """
@@ -723,7 +725,7 @@ class DivisionVolume(_PhysicalVolume):
         return f"Division volume : {self.name} {self.axis} {self.ndivisions} {self.offset} {self.width}"
 
     def extent(self, includeBoundingSolid=True):
-        _log.info(f"ReplicaVolume.extent> {self.name}")
+        _log.debug(f"ReplicaVolume.extent> {self.name}")
 
         vMin = [1e99, 1e99, 1e99]
         vMax = [-1e99, -1e99, -1e99]

--- a/src/pyg4ometry/geant4/LogicalVolume.py
+++ b/src/pyg4ometry/geant4/LogicalVolume.py
@@ -624,7 +624,6 @@ class LogicalVolume:
         self,
         recursive=False,
         coplanar=False,
-        debugIO=False,
         printOut=True,
         nOverlapsDetected=[0],
     ):
@@ -633,28 +632,25 @@ class LogicalVolume:
         default, overlaps are checked between daughter volumes and with the mother volume itself (protrusion).
         Coplanar overlaps may also be checked (default on).
 
-        Print out will be given for any overlaps detected and the visualiser will show the
+        logged error messages will be given for any overlaps detected and the visualiser will show the
         colour coded overlaps.
 
         :param recursive: bool - Whether to descend into the daughter volumes and check their contents also.
         :param coplanar: bool - Whether to check for coplanar overlaps
-        :param debugIO: bool - Print out for every check made
         :param printOut: bool - (internal) Whether to print out a summary of N overlaps detected
         :param nOverlapsDetected: [int] - (internal) counter for recursion - ignore
         """
         from ..geant4 import IsAReplica as _IsAReplica
 
-        if printOut:
-            print("LogicalVolume.checkOverlaps> ", self.name)
+        _log.debug("LogicalVolume.checkOverlaps> %s", self.name)
 
         # return if overlaps already checked
         if self.overlapChecked:
-            if debugIO:
-                print("Overlaps already checked - skipping")
+            _log.debug("Overlaps already checked - skipping")
             return
 
         if _IsAReplica(self):
-            self.daughterVolumes[0]._checkInternalOverlaps(debugIO, nOverlapsDetected)
+            self.daughterVolumes[0]._checkInternalOverlaps(nOverlapsDetected)
             self.overlapChecked = True
             return
 
@@ -670,7 +666,7 @@ class LogicalVolume:
             # in the case of say replicas
             if pv.type != "placement":
                 continue
-            _log.info(f"LogicalVolume.checkOverlaps> {pv.name}")
+            _log.debug(f"LogicalVolume.checkOverlaps> {pv.name}")
 
             # an assembly will generate more than one mesh, but a regular LV just one - in either case
             # use a list of meshes for applying transforms into this LV frame
@@ -722,10 +718,9 @@ class LogicalVolume:
         # overlap daughter pv checks
         for i in range(len(transformedMeshes)):
             for j in range(i + 1, len(transformedMeshes)):
-                if debugIO:
-                    print(
-                        f"LogicalVolume.checkOverlaps> daughter-daughter bounding mesh intersection test: {transformedMeshesNames[i]} {transformedMeshesNames[j]}"
-                    )
+                _log.debug(
+                    f"LogicalVolume.checkOverlaps> daughter-daughter bounding mesh intersection test: {transformedMeshesNames[i]} {transformedMeshesNames[j]}"
+                )
 
                 # first check if bounding mesh intersects
                 cullIntersection = transformedBoundingMeshes[i].intersect(
@@ -736,26 +731,23 @@ class LogicalVolume:
 
                 # bounding meshes collide, so check full mesh properly
                 interMesh = transformedMeshes[i].intersect(transformedMeshes[j])
-                _log.info(
+                _log.debug(
                     f"LogicalVolume.checkOverlaps> full daughter-daughter intersection test: {i} {j} {interMesh.vertexCount()} {interMesh.polygonCount()}"
                 )
                 if interMesh.vertexCount() != 0:
                     nOverlapsDetected[0] += 1
-                    print(
-                        f"\033[1mOVERLAP DETECTED> overlap between daughters of {self.name} \033[0m {transformedMeshesNames[i]} {transformedMeshesNames[j]} {interMesh.vertexCount()}"
+                    _log.error(
+                        f"OVERLAP DETECTED> overlap between daughters of {self.name} {transformedMeshesNames[i]} {transformedMeshesNames[j]} {interMesh.vertexCount()}"
                     )
                     self.mesh.addOverlapMesh([interMesh, _OverlapType.overlap])
 
         # coplanar daughter pv checks
-        # print 'coplanar with pvs'
-        # print "LogicalVolume.checkOverlaps> daughter coplanar overlaps"
         if coplanar:
             for i in range(len(transformedMeshes)):
                 for j in range(i + 1, len(transformedMeshes)):
-                    if debugIO:
-                        print(
-                            f"LogicalVolume.checkOverlaps> full coplanar test between daughters {transformedMeshesNames[i]} {transformedMeshesNames[j]}"
-                        )
+                    _log.debug(
+                        f"LogicalVolume.checkOverlaps> full coplanar test between daughters {transformedMeshesNames[i]} {transformedMeshesNames[j]}"
+                    )
 
                     # first check if bounding mesh intersects
                     cullIntersection = transformedBoundingMeshes[i].intersect(
@@ -764,49 +756,45 @@ class LogicalVolume:
                     cullCoplanar = transformedBoundingMeshes[i].coplanarIntersection(
                         transformedBoundingMeshes[j]
                     )
-                    print(cullIntersection.vertexCount(), cullCoplanar.vertexCount())
                     if cullIntersection.vertexCount() == 0 and cullCoplanar.vertexCount() == 0:
                         continue
 
                     coplanarMesh = transformedMeshes[i].coplanarIntersection(transformedMeshes[j])
                     if coplanarMesh.vertexCount() != 0:
                         nOverlapsDetected[0] += 1
-                        print(
-                            f"\033[1mOVERLAP DETECTED> coplanar overlap between daughters \033[0m {transformedMeshesNames[i]} {transformedMeshesNames[j]} {coplanarMesh.vertexCount()}"
+                        _log.error(
+                            f"OVERLAP DETECTED> coplanar overlap between daughters {transformedMeshesNames[i]} {transformedMeshesNames[j]} {coplanarMesh.vertexCount()}"
                         )
                         self.mesh.addOverlapMesh([coplanarMesh, _OverlapType.coplanar])
 
         # protrusion from mother solid
         for i in range(len(transformedMeshes)):
-            if debugIO:
-                print(
-                    f"LogicalVolume.checkOverlaps> full daughter-mother intersection test {transformedMeshesNames[i]}"
-                )
+            _log.debug(
+                f"LogicalVolume.checkOverlaps> full daughter-mother intersection test {transformedMeshesNames[i]}"
+            )
 
             cullIntersection = transformedBoundingMeshes[i].subtract(self.mesh.localboundingmesh)
             if cullIntersection.vertexCount() == 0:
                 continue
 
             interMesh = transformedMeshes[i].subtract(self.mesh.localmesh)
-            _log.info(
+            _log.debug(
                 f"LogicalVolume.checkOverlaps> daughter container {i} {interMesh.vertexCount()} {interMesh.polygonCount()}"
             )
 
             if interMesh.vertexCount() != 0:
                 nOverlapsDetected[0] += 1
-                print(
-                    f"\033[1mOVERLAP DETECTED> overlap with mother \033[0m {transformedMeshesNames[i]} {interMesh.vertexCount()}"
+                _log.error(
+                    f"OVERLAP DETECTED> overlap with mother {transformedMeshesNames[i]} {interMesh.vertexCount()}"
                 )
                 self.mesh.addOverlapMesh([interMesh, _OverlapType.protrusion])
 
         # coplanar with solid
-        # print 'coplanar with solid'
         if coplanar:
             for i in range(len(transformedMeshes)):
-                if debugIO:
-                    print(
-                        f"LogicalVolume.checkOverlaps> full daughter-mother coplanar test {transformedMeshesNames[i]}"
-                    ),
+                _log.debug(
+                    f"LogicalVolume.checkOverlaps> full daughter-mother coplanar test {transformedMeshesNames[i]}"
+                ),
 
                 # cullCoplanar = self.mesh.localboundingmesh.coplanarIntersection(transformedBoundingMeshes[i])
                 # if cullCoplanar.vertexCount() == 0 :
@@ -817,8 +805,8 @@ class LogicalVolume:
                 )  # Need mother.coplanar(daughter) as typically mother is larger
                 if coplanarMesh.vertexCount() != 0:
                     nOverlapsDetected[0] += 1
-                    print(
-                        f"\033[1mOVERLAP DETECTED> coplanar overlap between daughter and mother\033[0m {transformedMeshesNames[i]} {coplanarMesh.vertexCount()}"
+                    _log.error(
+                        f"OVERLAP DETECTED> coplanar overlap between daughter and mother {transformedMeshesNames[i]} {coplanarMesh.vertexCount()}"
                     )
                     self.mesh.addOverlapMesh([coplanarMesh, _OverlapType.coplanar])
 
@@ -831,7 +819,6 @@ class LogicalVolume:
                 d.logicalVolume.checkOverlaps(
                     recursive=recursive,
                     coplanar=coplanar,
-                    debugIO=debugIO,
                     printOut=False,
                     nOverlapsDetected=nOverlapsDetected,
                 )
@@ -840,7 +827,11 @@ class LogicalVolume:
         self.overlapChecked = True
 
         if printOut:
-            print(nOverlapsDetected[0], " overlaps detected")
+            _log.log(
+                _logging.ERROR if nOverlapsDetected[0] > 0 else _logging.INFO,
+                "%d overlaps detected",
+                nOverlapsDetected[0],
+            )
 
     def setSolid(self, solid):
         """

--- a/src/pyg4ometry/geant4/ParameterisedVolume.py
+++ b/src/pyg4ometry/geant4/ParameterisedVolume.py
@@ -6,6 +6,8 @@ from .. import transformation as _trans
 import numpy as _np
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class ParameterisedVolume(_ReplicaVolume):
     """ParametrisedVolume
@@ -480,7 +482,7 @@ class ParameterisedVolume(_ReplicaVolume):
         return ""
 
     def extent(self, includeBoundingSolid=True):
-        _log.info(f"ParametrisedVolume.extent> {self.name}")
+        _log.debug(f"ParametrisedVolume.extent> {self.name}")
 
         vMin = [1e99, 1e99, 1e99]
         vMax = [-1e99, -1e99, -1e99]

--- a/src/pyg4ometry/geant4/PhysicalVolume.py
+++ b/src/pyg4ometry/geant4/PhysicalVolume.py
@@ -6,6 +6,8 @@ from ..visualisation import Mesh as _Mesh
 import numpy as _np
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class PhysicalVolume:
     """
@@ -115,7 +117,7 @@ class PhysicalVolume:
         )
 
     def extent(self, includeBoundingSolid=True):
-        _log.info(f"PhysicalVolume.extent> {self.name}")
+        _log.debug(f"PhysicalVolume.extent> {self.name}")
 
         # transform daughter meshes to parent coordinates
         dvmrot = _trans.tbxyz2matrix(self.rotation.eval())

--- a/src/pyg4ometry/geant4/Registry.py
+++ b/src/pyg4ometry/geant4/Registry.py
@@ -2,6 +2,7 @@ from .. import exceptions as _exceptions
 from . import _Material as _mat
 from . import solid
 
+import logging as _log
 from collections import defaultdict as _defaultdict
 
 
@@ -653,7 +654,7 @@ class Registry:
             # add members from logical volume
             self.transferLogicalVolume(volume, incrementRenameDict, userRenameDict)
         else:
-            print(f"Volume type not supported yet for merging type='{volume.type}'")
+            _log.error(f"Volume type not supported yet for merging type='{volume.type}'")
 
         return incrementRenameDict
 
@@ -860,8 +861,8 @@ class Registry:
         return self.worldVolume
 
     def printStats(self):
-        print(self.solidTypeCountDict)
-        print(self.logicalVolumeUsageCountDict)
+        print(self.solidTypeCountDict)  # noqa: T201
+        print(self.logicalVolumeUsageCountDict)  # noqa: T201
 
     def structureAnalysis(self, lv_name=None, debug=False, level=0, df=None):
         return AnalyseGeometryStructure(self, lv_name, debug, level, df)
@@ -917,28 +918,28 @@ class GeometryComplexityInformation:
         self.booleanDepth = _defaultdict(int)
 
     def printSummary(self, boolDepthLimit=3):
-        print("Types of solids")
+        print("Types of solids")  # noqa: T201
         solidsSorted = sorted(self.solids.items(), key=lambda x: x[1], reverse=True)
         for solidName, number in solidsSorted:
-            print(solidName.ljust(20), ":", number)
+            print(solidName.ljust(20), ":", number)  # noqa: T201
 
-        print(" ")
-        print("# of daughters".ljust(20), "count")
+        print(" ")  # noqa: T201
+        print("# of daughters".ljust(20), "count")  # noqa: T201
         for nDaughters in sorted(self.nDaughtersPerLV.keys()):
-            print(str(nDaughters).ljust(20), ":", self.nDaughtersPerLV[nDaughters])
+            print(str(nDaughters).ljust(20), ":", self.nDaughtersPerLV[nDaughters])  # noqa: T201
 
-        print(" ")
-        print("Depth of booleans".ljust(20), "count")
+        print(" ")  # noqa: T201
+        print("Depth of booleans".ljust(20), "count")  # noqa: T201
         for boolDepth in sorted(self.booleanDepthCount.keys()):
-            print(str(boolDepth).ljust(20), ":", self.booleanDepthCount[boolDepth])
+            print(str(boolDepth).ljust(20), ":", self.booleanDepthCount[boolDepth])  # noqa: T201
 
-        print(" ")
-        print("Booleans width depth over ", boolDepthLimit)
-        print("Solid name".ljust(40), ":", "n Booleans")
+        print(" ")  # noqa: T201
+        print("Booleans width depth over ", boolDepthLimit)  # noqa: T201
+        print("Solid name".ljust(40), ":", "n Booleans")  # noqa: T201
         boolDepthSorted = sorted(self.booleanDepth.items(), key=lambda x: x[1], reverse=True)
         for solidName, boolDepth in boolDepthSorted:
             if boolDepth > boolDepthLimit:
-                print(solidName.ljust(40), ":", boolDepth)
+                print(solidName.ljust(40), ":", boolDepth)  # noqa: T201
 
 
 def AnalyseGeometryComplexity(logicalVolume):
@@ -1045,9 +1046,9 @@ def AnalyseGeometryStructure(registry, lv_name=None, debug=False, level=0, df=No
     )
 
     if debug:
-        print("\nlevel:", level)
-        print("mother:", mother)
-        print("daughters: ", len(daughters), " ", daughters)
+        _log.debug("\nlevel: %s", level)
+        _log.debug("mother: %s", mother)
+        _log.debug("daughters: %d %s", len(daughters), daughters)
 
     level += 1
 
@@ -1063,9 +1064,9 @@ def AnalyseGeometryStructure(registry, lv_name=None, debug=False, level=0, df=No
 
 
 def DumpGeometryStructureTree(lv, depth=0):
-    print(4 * (depth - 1) * " " + 4 * "-" + ">" + lv.name)
+    print(4 * (depth - 1) * " " + 4 * "-" + ">" + lv.name)  # noqa: T201
 
     for dv in lv.daughterVolumes:
-        print(4 * (depth + 1) * " " + 4 * "-" + ">" + dv.name + " (pv)")
+        print(4 * (depth + 1) * " " + 4 * "-" + ">" + dv.name + " (pv)")  # noqa: T201
 
         DumpGeometryStructureTree(dv.logicalVolume, depth + 3)

--- a/src/pyg4ometry/geant4/ReplicaVolume.py
+++ b/src/pyg4ometry/geant4/ReplicaVolume.py
@@ -8,6 +8,8 @@ from .. import transformation as _trans
 import numpy as _np
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class ReplicaVolume(_PhysicalVolume):
     """

--- a/src/pyg4ometry/geant4/ReplicaVolume.py
+++ b/src/pyg4ometry/geant4/ReplicaVolume.py
@@ -76,7 +76,7 @@ class ReplicaVolume(_PhysicalVolume):
         names = {1: "kXAxis", 2: "kYAxis", 3: "kZAxis", 4: "kRho", 5: "kPhi"}
         return names[self.axis]
 
-    def _checkInternalOverlaps(self, debugIO=False, nOverlapsDetected=[0]):
+    def _checkInternalOverlaps(self, nOverlapsDetected=[0]):
         """
         Check if there are overlaps with the nominal mother volume. ie it possible to provide
         an incorrect mother volume / logical volume and parameterisation.
@@ -91,30 +91,28 @@ class ReplicaVolume(_PhysicalVolume):
             tempMeshes.append(mt)
 
         for i in range(len(tempMeshes)):
-            if debugIO:
-                print(
-                    f"ReplicaVolume.checkOverlaps> full daughter-mother intersection test {self.meshes[i]}"
-                )
+            _log.debug(
+                f"ReplicaVolume.checkOverlaps> full daughter-mother intersection test {self.meshes[i]}"
+            )
 
             interMesh = tempMeshes[i].subtract(self.motherVolume.mesh.localboundingmesh)
-            _log.info(
+            _log.debug(
                 f"ReplicaVolume.checkOverlaps> daughter container {i} {interMesh.vertexCount()} {interMesh.polygonCount()}"
             )
 
             if interMesh.vertexCount() != 0:
                 nOverlapsDetected[0] += 1
-                print(
-                    f"\033[1mOVERLAP DETECTED> overlap with mother \033[0m {tempMeshes[i]} {interMesh.vertexCount()}"
+                _log.error(
+                    f"OVERLAP DETECTED> overlap with mother {tempMeshes[i]} {interMesh.vertexCount()}"
                 )
                 self.motherVolume.mesh.addOverlapMesh([interMesh, _OverlapType.protrusion])
 
         # daughter-daughter overlap check
         for i in range(len(tempMeshes)):
             for j in range(i + 1, len(tempMeshes)):
-                if debugIO:
-                    print(
-                        f"ReplicaVolume.checkOverlaps> daughter-daughter bounding mesh intersection test: #{i} #{j}"
-                    )
+                _log.debug(
+                    f"ReplicaVolume.checkOverlaps> daughter-daughter bounding mesh intersection test: #{i} #{j}"
+                )
 
                 # first check if bounding mesh intersects
                 cullIntersection = tempMeshes[i].intersect(tempMeshes[j])
@@ -123,13 +121,13 @@ class ReplicaVolume(_PhysicalVolume):
 
                 # bounding meshes collide, so check full mesh properly
                 interMesh = tempMeshes[i].intersect(tempMeshes[j])
-                _log.info(
+                _log.debug(
                     f"ReplicaVolume.checkOverlaps> full daughter-daughter intersection test: {i} {j} {interMesh.vertexCount()} {interMesh.polygonCount()}"
                 )
                 if interMesh.vertexCount() != 0:
                     nOverlapsDetected[0] += 1
-                    print(
-                        f"\033[1mOVERLAP DETECTED> overlap between daughters of {self.name} \033[0m #{i} #{j} {interMesh.vertexCount()}"
+                    _log.error(
+                        f"OVERLAP DETECTED> overlap between daughters of {self.name} #{i} #{j} {interMesh.vertexCount()}"
                     )
                     self.motherVolume.mesh.addOverlapMesh([interMesh, _OverlapType.overlap])
 

--- a/src/pyg4ometry/geant4/_Material.py
+++ b/src/pyg4ometry/geant4/_Material.py
@@ -411,8 +411,8 @@ class Material(MaterialBase):
             if kwargs.get("tolerateZeroDensity", False):
                 # this behaviour is to match Geant4's tolerance of 0 density which if forbids
                 # if loaded in Geant4, it would enforce a minimum without an exception
-                print(
-                    f"Warning in Material : '{self.name}' density set to 0, ensuring minimum of 1e-20"
+                _log.warning(
+                    "Material : '%s' density set to 0, ensuring minimum of 1e-20", self.name
                 )
                 self.density = 1e-20
                 self.type = "simple"
@@ -549,6 +549,9 @@ class Material(MaterialBase):
         """
         from ..gdml import Defines as defines
 
+        if vunit.find("/") == 0:
+            msg = f"invalid unit format: use 1/unit instead of /unit in {vunit}."
+            raise ValueError(msg)
         matrix_name = self.name + "_" + name
         m = defines.MatrixFromVectors(e, v, matrix_name, self.registry, eunit, vunit)
         self.addProperty(name, m)
@@ -567,8 +570,9 @@ class Material(MaterialBase):
         """
         from ..gdml import Defines as defines
 
-        if vunit.find("/") != -1:
-            print("Please use 1/unit.")
+        if vunit.find("/") == 0:
+            msg = f"invalid unit format: use 1/unit instead of /unit in {vunit}."
+            raise ValueError(msg)
         vunit = "*" + vunit if vunit != "" else ""
         matrix_name = self.name + "_" + name
         m = defines.Matrix(matrix_name, 1, [str(value) + vunit], self.registry)

--- a/src/pyg4ometry/geant4/solid/Box.py
+++ b/src/pyg4ometry/geant4/solid/Box.py
@@ -15,6 +15,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 def cubeNet(vecList):
     return _CSG.fromPolygons(
@@ -113,7 +115,7 @@ class Box(_SolidBase):
         return f"Box : name={self.name} x={float(self.pX)} y={float(self.pY)} z={float(self.pZ)}"
 
     def mesh(self):
-        _log.info("box.pycsgmesh> antlr")
+        _log.debug("box.pycsgmesh> antlr")
         from ...gdml import Units as _Units
 
         uval = _Units.unit(self.lunit)

--- a/src/pyg4ometry/geant4/solid/Cons.py
+++ b/src/pyg4ometry/geant4/solid/Cons.py
@@ -17,6 +17,8 @@ import numpy as _np
 
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class Cons(_SolidBase):
     """
@@ -122,7 +124,7 @@ class Cons(_SolidBase):
         return f"Cons : name={self.name} rmin1={float(self.pRmin1)} rmax1={float(self.pRmax1)} rmin2={float(self.pRmin2)} rmax2={float(self.pRmax2)} dz={float(self.pDz)} sphi={float(self.pSPhi)} dphi={float(self.pDPhi)}"
 
     def mesh(self):
-        _log.info("cons.antlr>")
+        _log.debug("cons.antlr>")
 
         from ...gdml import Units as _Units
 
@@ -137,7 +139,7 @@ class Cons(_SolidBase):
         pSPhi = self.evaluateParameter(self.pSPhi) * auval
         pDPhi = self.evaluateParameter(self.pDPhi) * auval
 
-        _log.info("cons.pycsgmesh>")
+        _log.debug("cons.pycsgmesh>")
 
         from .GenericPolyhedra import GenericPolyhedra as _GenericPolyhedra
 

--- a/src/pyg4ometry/geant4/solid/CutTubs.py
+++ b/src/pyg4ometry/geant4/solid/CutTubs.py
@@ -16,6 +16,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 import numpy as _np
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class CutTubs(_SolidBase):
     """
@@ -106,7 +108,7 @@ class CutTubs(_SolidBase):
 
     def mesh(self):
         # 0.00943803787231 66
-        _log.info("tubs.pycsgmesh> antlr")
+        _log.debug("tubs.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -122,7 +124,7 @@ class CutTubs(_SolidBase):
         pHighNorm = [val * luval for val in self.evaluateParameter(self.pHighNorm)]
         pLowNorm = [val * luval for val in self.evaluateParameter(self.pLowNorm)]
 
-        _log.info("tubs.pycsgmesh> mesh")
+        _log.debug("tubs.pycsgmesh> mesh")
 
         polygons = []
 

--- a/src/pyg4ometry/geant4/solid/Ellipsoid.py
+++ b/src/pyg4ometry/geant4/solid/Ellipsoid.py
@@ -17,6 +17,8 @@ import logging as _log
 
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class Ellipsoid(_SolidBase):
     """
@@ -89,7 +91,7 @@ class Ellipsoid(_SolidBase):
         return f"Ellipsoid : name={self.name} xSemiAxis={float(self.pxSemiAxis)} ySemiAxis={float(self.pySemiAxis)} zSemiAxis={float(self.pzSemiAxis)} zBottomCut={float(self.pzBottomCut)} zTopCut={float(self.pzTopCut)}"
 
     def mesh(self):
-        _log.info("ellipsoid.antlr>")
+        _log.debug("ellipsoid.antlr>")
 
         from ...gdml import Units as _Units
 
@@ -101,7 +103,7 @@ class Ellipsoid(_SolidBase):
         pzBottomCut = float(self.pzBottomCut) * luval
         pzTopCut = float(self.pzTopCut) * luval
 
-        _log.info("ellipsoid.pycsgmesh>")
+        _log.debug("ellipsoid.pycsgmesh>")
 
         slices = self.nslice
         stacks = self.nstack

--- a/src/pyg4ometry/geant4/solid/EllipticalCone.py
+++ b/src/pyg4ometry/geant4/solid/EllipticalCone.py
@@ -17,6 +17,8 @@ import logging as _log
 
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class EllipticalCone(_SolidBase):
     """
@@ -75,7 +77,7 @@ class EllipticalCone(_SolidBase):
         return f"EllipticalCone : name={self.name} xSemiAxis={float(self.pxSemiAxis)} ySemiAxis={float(self.pySemiAxis)} zMax={float(self.zMax)} zTopCut={float(self.pzTopCut)}"
 
     def mesh(self):
-        _log.info("ellipticalcone.antlr>")
+        _log.debug("ellipticalcone.antlr>")
 
         from ...gdml import Units as _Units
 
@@ -87,7 +89,7 @@ class EllipticalCone(_SolidBase):
         pzTopCut = self.evaluateParameter(self.pzTopCut) * luval
         pzTopCut = min(zMax, pzTopCut)  # Accounting for if cut > zmax.
 
-        _log.info("ellipticalcone.pycsgmesh>")
+        _log.debug("ellipticalcone.pycsgmesh>")
         polygons = []
 
         # smaller face semi-axis (at z=ztopcut)

--- a/src/pyg4ometry/geant4/solid/EllipticalTube.py
+++ b/src/pyg4ometry/geant4/solid/EllipticalTube.py
@@ -17,6 +17,8 @@ import logging as _log
 
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class EllipticalTube(_SolidBase):
     """
@@ -79,7 +81,7 @@ class EllipticalTube(_SolidBase):
     def mesh(self):
         """new meshing based of Tubs meshing"""
 
-        _log.info("ellipticaltube.antlr>")
+        _log.debug("ellipticaltube.antlr>")
 
         from ...gdml import Units as _Units
 
@@ -89,7 +91,7 @@ class EllipticalTube(_SolidBase):
         pDy = self.evaluateParameter(self.pDy) * luval
         pDz = self.evaluateParameter(self.pDz) * luval
 
-        _log.info("ellipticaltube.pycsgmesh>")
+        _log.debug("ellipticaltube.pycsgmesh>")
 
         polygons = []
 

--- a/src/pyg4ometry/geant4/solid/ExtrudedSolid.py
+++ b/src/pyg4ometry/geant4/solid/ExtrudedSolid.py
@@ -19,6 +19,8 @@ import numpy as _np
 
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class ExtrudedSolid(_SolidBase):
     """
@@ -103,7 +105,7 @@ class ExtrudedSolid(_SolidBase):
             raise RuntimeError(msg)
 
     def mesh(self):
-        _log.info("xtru.pycsgmesh> antlr")
+        _log.debug("xtru.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -119,7 +121,7 @@ class ExtrudedSolid(_SolidBase):
         vertices = [[pPolygon[0] * luval, pPolygon[1] * luval] for pPolygon in pPolygon]
         nslices = len(pZslices)
 
-        _log.info("xtru.pycsgmesh> mesh")
+        _log.debug("xtru.pycsgmesh> mesh")
         polygons = []
         polygonsT = []
         polygonsB = []

--- a/src/pyg4ometry/geant4/solid/GenericPolycone.py
+++ b/src/pyg4ometry/geant4/solid/GenericPolycone.py
@@ -6,6 +6,8 @@ from .GenericPolyhedra import GenericPolyhedra as _GenericPolyhedra
 import logging as _log
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class GenericPolycone(_SolidBase):
     """
@@ -79,7 +81,7 @@ class GenericPolycone(_SolidBase):
             raise ValueError(msg)
 
     def mesh(self):
-        _log.info("genericpolycone.antlr>")
+        _log.debug("genericpolycone.antlr>")
 
         from ...gdml import Units as _Units
 

--- a/src/pyg4ometry/geant4/solid/GenericPolyhedra.py
+++ b/src/pyg4ometry/geant4/solid/GenericPolyhedra.py
@@ -17,6 +17,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 import logging as _log
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class GenericPolyhedra(_SolidBase):
     """
@@ -82,7 +84,7 @@ class GenericPolyhedra(_SolidBase):
             raise ValueError(msg)
 
     def mesh(self):
-        _log.info("genericpolyhedra.antlr>")
+        _log.debug("genericpolyhedra.antlr>")
 
         from ...gdml import Units as _Units
 

--- a/src/pyg4ometry/geant4/solid/GenericTrap.py
+++ b/src/pyg4ometry/geant4/solid/GenericTrap.py
@@ -17,6 +17,8 @@ import logging as _log
 
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class GenericTrap(_SolidBase):
     """
@@ -123,8 +125,7 @@ class GenericTrap(_SolidBase):
         signed_area = 0.5 * (_np.dot(x, _np.roll(y, 1)) - _np.dot(y, _np.roll(x, 1)))
         if not signed_area:
             return 0
-            print("vertices: ", vertices)
-            msg = f"GenericTrap: '{self.name}' Zero area quadrilateral not allowed."
+            msg = f"GenericTrap: '{self.name}' Zero area quadrilateral not allowed. vertices: {vertices!s}"
             raise ValueError(msg)  # TODO TODO
         return signed_area
 
@@ -171,7 +172,7 @@ class GenericTrap(_SolidBase):
         return layers
 
     def mesh(self):
-        _log.info("arb8.mesh> antlr")
+        _log.debug("arb8.mesh> antlr")
 
         verts_top = []
         verts_bot = []
@@ -191,7 +192,7 @@ class GenericTrap(_SolidBase):
 
         all_verts = self.makeLayers(verts_bot, verts_top)
 
-        _log.info("arb8.mesh> mesh")
+        _log.debug("arb8.mesh> mesh")
         polygons = []
 
         # Mesh top and bottom pieces

--- a/src/pyg4ometry/geant4/solid/HalfSpace.py
+++ b/src/pyg4ometry/geant4/solid/HalfSpace.py
@@ -15,6 +15,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class HalfSpace(_SolidBase):
     def __init__(self, name, registry=None):

--- a/src/pyg4ometry/geant4/solid/Hype.py
+++ b/src/pyg4ometry/geant4/solid/Hype.py
@@ -13,10 +13,11 @@ elif _config.meshing == _config.meshingType.cgal_sm:
     from ...pycgal.geom import Vertex as _Vertex
     from ...pycgal.geom import Polygon as _Polygon
 
-from copy import deepcopy as _dc
 import logging as _log
 
 import numpy as _np
+
+_log = _log.getLogger(__name__)
 
 
 class Hype(_SolidBase):
@@ -101,7 +102,7 @@ class Hype(_SolidBase):
             raise ValueError(msg)
 
     def mesh(self):
-        _log.info("hype.pycsgmesh> antlr")
+        _log.debug("hype.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -115,7 +116,7 @@ class Hype(_SolidBase):
         LenZ = self.evaluateParameter(self.lenZ) * luval
         halfLenZ = self.evaluateParameter(self.lenZ) / 2.0 * luval
 
-        _log.info("hype.pycsgmesh> mesh")
+        _log.debug("hype.pycsgmesh> mesh")
 
         dz = LenZ / self.nstack
         sz = -halfLenZ

--- a/src/pyg4ometry/geant4/solid/Intersection.py
+++ b/src/pyg4ometry/geant4/solid/Intersection.py
@@ -5,6 +5,8 @@ import logging as _log
 
 from ... import exceptions
 
+_log = _log.getLogger(__name__)
+
 
 class Intersection(_SolidBase):
     """
@@ -61,7 +63,7 @@ class Intersection(_SolidBase):
     def mesh(self):
         from ... import geant4 as _g4
 
-        _log.info("Intersection.pycsgmesh>>")
+        _log.debug("Intersection.pycsgmesh>>")
 
         # look up solids in registry
         obj1 = self.registry.solidDict.get(_g4.solidName(self.obj1), self.obj1)
@@ -72,21 +74,20 @@ class Intersection(_SolidBase):
         tlate = self.tra2[1].eval()
 
         # get meshes
-        _log.info("Intersection.mesh> mesh1")
+        _log.debug("Intersection.mesh> mesh1")
         m1 = obj1.mesh()
-        _log.info("Intersection.mesh> mesh2")
+        _log.debug("Intersection.mesh> mesh2")
         m2 = obj2.mesh().clone()
 
         # apply transform to second mesh
         m2.rotate(rot[0], -rad2deg(rot[1]))
         m2.translate(tlate)
 
-        _log.info("Intersection.pycsgmesh> intersect")
+        _log.debug("Intersection.pycsgmesh> intersect")
         mesh = m1.intersect(m2)
         if mesh.isNull():
             raise exceptions.NullMeshError(self)
 
-        # print 'intersection mesh ', self.name
         return mesh
 
     def translation(self):

--- a/src/pyg4ometry/geant4/solid/MultiUnion.py
+++ b/src/pyg4ometry/geant4/solid/MultiUnion.py
@@ -5,6 +5,8 @@ from ...transformation import *
 import copy as _copy
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class MultiUnion(_SolidBase):
     """
@@ -49,7 +51,7 @@ class MultiUnion(_SolidBase):
         return f"Multi Union {self.name}"
 
     def mesh(self):
-        _log.info("MultiUnion.pycsgmesh>")
+        _log.debug("MultiUnion.pycsgmesh>")
 
         result = self.objects[0].mesh()
         tra2 = self.transformations[0]
@@ -64,17 +66,17 @@ class MultiUnion(_SolidBase):
             # tranformation
             rot = tbxyz2axisangle(tra2[0].eval())
             tlate = tra2[1].eval()
-            _log.info(f"MulUnion.mesh> rot={rot!s} tlate={tlate!s}")
+            _log.debug(f"MulUnion.mesh> rot={rot!s} tlate={tlate!s}")
 
             # get meshes
-            _log.info(f"union.mesh> mesh {idx}")
+            _log.debug(f"union.mesh> mesh {idx}")
             mesh = solid.mesh()
 
             # apply transform to second mesh
             mesh.rotate(rot[0], -rad2deg(rot[1]))
             mesh.translate(tlate)
 
-            _log.info("MultiUnion.mesh> union")
+            _log.debug("MultiUnion.mesh> union")
             result = result.union(mesh)
 
         return result

--- a/src/pyg4ometry/geant4/solid/Orb.py
+++ b/src/pyg4ometry/geant4/solid/Orb.py
@@ -16,6 +16,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 import logging as _log
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class Orb(_SolidBase):
     """
@@ -68,21 +70,21 @@ class Orb(_SolidBase):
 
     """'
     def pycsgmeshOld(self):
-        _log.info("orb.antlr>")
+        _log.debug("orb.antlr>")
 
         import pyg4ometry.gdml.Units as _Units #TODO move circular import
         luval = _Units.unit(self.lunit)
 
         pRMax = self.evaluateParameter(self.pRMax)*luval
 
-        _log.info("orb.pycsgmesh>")
+        _log.debug("orb.pycsgmesh>")
         mesh = _CSG.sphere(center=[0,0,0], radius=pRMax,
                            slices=self.nslice, stacks=self.nstack)
         return mesh
     """
 
     def mesh(self):
-        _log.info("orb.antlr>")
+        _log.debug("orb.antlr>")
 
         from ...gdml import Units as _Units
 
@@ -92,7 +94,7 @@ class Orb(_SolidBase):
 
         polygons = []
 
-        _log.info("orb.pycsgmesh>")
+        _log.debug("orb.pycsgmesh>")
 
         dPhi = 2 * _np.pi / self.nslice
         dTheta = _np.pi / self.nstack

--- a/src/pyg4ometry/geant4/solid/Para.py
+++ b/src/pyg4ometry/geant4/solid/Para.py
@@ -18,6 +18,8 @@ import logging as _log
 import numpy as _np
 import math as _math
 
+_log = _log.getLogger(__name__)
+
 
 class Para(_SolidBase):
     """
@@ -87,7 +89,7 @@ class Para(_SolidBase):
         return f"Para : name={self.name} x={float(self.pX)} y={float(self.pY)} z={float(self.pZ)} alpha={float(self.pAlpha)} theta={float(self.pTheta)} phi={float(self.pPhi)}"
 
     def mesh(self):
-        _log.info("para.antlr>")
+        _log.debug("para.antlr>")
         from ...gdml import Units as _Units
 
         luval = _Units.unit(self.lunit)
@@ -100,7 +102,7 @@ class Para(_SolidBase):
         pTheta = self.evaluateParameter(self.pTheta) * auval
         pPhi = self.evaluateParameter(self.pPhi) * auval
 
-        _log.info("para.pycsgmesh>")
+        _log.debug("para.pycsgmesh>")
 
         va = _Vector(pX, 0, 0)
         vb = pY / _math.cos(pAlpha) * _Vector(_math.sin(pAlpha), _math.cos(pAlpha), 0)

--- a/src/pyg4ometry/geant4/solid/Paraboloid.py
+++ b/src/pyg4ometry/geant4/solid/Paraboloid.py
@@ -16,6 +16,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 import logging as _log
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class Paraboloid(_SolidBase):
     """
@@ -78,14 +80,14 @@ class Paraboloid(_SolidBase):
     def mesh(self):
         from ...gdml import Units as _Units
 
-        _log.info("paraboloid.antlr>")
+        _log.debug("paraboloid.antlr>")
 
         uval = _Units.unit(self.lunit)
         pDz = self.evaluateParameter(self.pDz) / 2.0 * uval
         pR1 = self.evaluateParameter(self.pR1) * uval
         pR2 = self.evaluateParameter(self.pR2) * uval
 
-        _log.info("paraboloid.pycsgmesh>")
+        _log.debug("paraboloid.pycsgmesh>")
         polygons = []
 
         sz = -pDz

--- a/src/pyg4ometry/geant4/solid/Polycone.py
+++ b/src/pyg4ometry/geant4/solid/Polycone.py
@@ -5,6 +5,8 @@ from .GenericPolyhedra import GenericPolyhedra as _GenericPolyhedra
 
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class Polycone(_SolidBase):
     """
@@ -78,9 +80,9 @@ class Polycone(_SolidBase):
         return f"Polycone : name={self.name} sphi={float(self.pSPhi)} dphi={float(self.pDPhi)}"
 
     def mesh(self):
-        _log.info("polycone.pycsgmesh>")
+        _log.debug("polycone.pycsgmesh>")
 
-        _log.info("polycone.antlr>")
+        _log.debug("polycone.antlr>")
 
         from ...gdml import Units as _Units
 

--- a/src/pyg4ometry/geant4/solid/Polyhedra.py
+++ b/src/pyg4ometry/geant4/solid/Polyhedra.py
@@ -3,6 +3,8 @@ from .SolidBase import SolidBase as _SolidBase
 import logging as _log
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class Polyhedra(_SolidBase):
     """
@@ -85,7 +87,7 @@ class Polyhedra(_SolidBase):
         return f"Polyhedra : name={self.name} sphi={self.pSPhi!s} dphi={self.pDPhi!s} numside={self.numSide!s} numzplanes={self.numZPlanes!s}"
 
     def mesh(self):
-        _log.info("polyhedra.antlr>")
+        _log.debug("polyhedra.antlr>")
 
         from ...gdml import Units as _Units
 

--- a/src/pyg4ometry/geant4/solid/Scaled.py
+++ b/src/pyg4ometry/geant4/solid/Scaled.py
@@ -3,6 +3,8 @@ from ...pycsg.core import CSG as _CSG
 
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class Scaled(_SolidBase):
     """
@@ -46,7 +48,7 @@ class Scaled(_SolidBase):
     def mesh(self):
         from ...gdml import Units as _Units
 
-        _log.info("scaled.pycsgmesh> antlr")
+        _log.debug("scaled.pycsgmesh> antlr")
 
         pX = self.evaluateParameter(self.pX)
         pY = self.evaluateParameter(self.pY)
@@ -55,5 +57,5 @@ class Scaled(_SolidBase):
         mesh = self.solid.mesh()
         mesh.scale([pX, pY, pZ])
 
-        _log.info("scaled.pycsgmesh> mesh")
+        _log.debug("scaled.pycsgmesh> mesh")
         return mesh

--- a/src/pyg4ometry/geant4/solid/Sphere.py
+++ b/src/pyg4ometry/geant4/solid/Sphere.py
@@ -22,6 +22,8 @@ import logging as _log
 # import resource as _resource
 import time as _time
 
+_log = _log.getLogger(__name__)
+
 
 class Sphere(_SolidBase):
     """
@@ -119,7 +121,7 @@ class Sphere(_SolidBase):
 
         tBefore = _time.process_time()
 
-        _log.info("sphere.antlr>")
+        _log.debug("sphere.antlr>")
         from ...gdml import Units as _Units
 
         luval = _Units.unit(self.lunit)
@@ -132,7 +134,7 @@ class Sphere(_SolidBase):
         pSTheta = self.evaluateParameter(self.pSTheta) * auval
         pDTheta = self.evaluateParameter(self.pDTheta) * auval
 
-        _log.info("Sphere.pycsgmesh>")
+        _log.debug("Sphere.pycsgmesh>")
 
         polygons = []
 
@@ -299,7 +301,7 @@ class Sphere(_SolidBase):
         # mBefore = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
         mesh = _CSG.fromPolygons(polygons)
         # mAfter = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
-        # _log.info(
+        # _log.debug(
         #    f"Sphere.pycsgmesh> profile {self.nstack} {self.nslice} {mesh.getNumberPolys()} {mAfter - mBefore} {tAfter - tBefore}"
         # )
         return mesh

--- a/src/pyg4ometry/geant4/solid/Subtraction.py
+++ b/src/pyg4ometry/geant4/solid/Subtraction.py
@@ -5,6 +5,8 @@ from ...transformation import *
 
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class Subtraction(_SolidBase):
     """
@@ -48,7 +50,7 @@ class Subtraction(_SolidBase):
         return f"Intersection {self.name} {self.obj1.name!s} {self.obj2.name!s}"
 
     def mesh(self):
-        _log.info("subtraction.pycsgmesh>")
+        _log.debug("subtraction.pycsgmesh>")
 
         # look up solids in registry
         from ... import geant4 as _g4
@@ -61,9 +63,9 @@ class Subtraction(_SolidBase):
         tlate = self.tra2[1].eval()
 
         # get meshes
-        _log.info("subtraction.mesh> mesh1")
+        _log.debug("subtraction.mesh> mesh1")
         m1 = obj1.mesh()
-        _log.info("subtraction.mesh> mesh2")
+        _log.debug("subtraction.mesh> mesh2")
         m2 = obj2.mesh().clone()
 
         m2.rotate(rot[0], -rad2deg(rot[1]))
@@ -71,10 +73,10 @@ class Subtraction(_SolidBase):
 
         self.obj2mesh = m2
 
-        _log.info("subtraction.pycshmsh> subtraction")
+        _log.debug("subtraction.pycshmsh> subtraction")
         mesh = m1.subtract(m2)
         if mesh.isNull():
-            print("Warning> Subtraction null mesh solid name : ", self.name)
+            _log.warning("subtraction.pycshmsh> Subtraction null mesh solid name : %s", self.name)
             if _config.meshingNullException:
                 raise exceptions.NullMeshError(self)
 

--- a/src/pyg4ometry/geant4/solid/TessellatedSolid.py
+++ b/src/pyg4ometry/geant4/solid/TessellatedSolid.py
@@ -14,6 +14,9 @@ elif _config.meshing == _config.meshingType.cgal_sm:
     from ...pycgal.geom import Polygon as _Polygon
 
 import numpy as _np
+import logging as _log
+
+_log = _log.getLogger(__name__)
 
 
 class TessellatedSolid(_SolidBase):
@@ -75,10 +78,8 @@ class TessellatedSolid(_SolidBase):
         self.meshtess[1].append(triangle)
 
     def removeDuplicateVertices(self):
-        # print("removeDuplicateVertices")
-
         if self.meshtype != TessellatedSolid.MeshType.Freecad:
-            print("Cannot run on this mesh type")
+            _log.warning("Cannot run on this mesh type")
             return
 
         vertexmap = {}

--- a/src/pyg4ometry/geant4/solid/Tet.py
+++ b/src/pyg4ometry/geant4/solid/Tet.py
@@ -15,7 +15,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 
 import numpy as _np
 import logging as _log
-from copy import deepcopy as _dc
+
+_log = _log.getLogger(__name__)
 
 
 class Tet(_SolidBase):
@@ -75,7 +76,7 @@ class Tet(_SolidBase):
         return f"Tet : name={self.name} Vertexes: a={self.anchor!s}, p2={self.p2!s}, p3={self.p3!s}, p4={self.p4!s}"
 
     def mesh(self):
-        _log.info("tet.pycsgmesh> antlr")
+        _log.debug("tet.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -86,7 +87,7 @@ class Tet(_SolidBase):
         p3 = [val * luval for val in self.evaluateParameter(self.p3)]
         p4 = [val * luval for val in self.evaluateParameter(self.p4)]
 
-        _log.info("tet.pycsgmesh> mesh")
+        _log.debug("tet.pycsgmesh> mesh")
         vert_ancr = _Vertex(_Vector(p4[0], p4[1], p4[2]))
         base = [anchor, p2, p3]
         vert_base = []

--- a/src/pyg4ometry/geant4/solid/Torus.py
+++ b/src/pyg4ometry/geant4/solid/Torus.py
@@ -16,6 +16,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 import numpy as _np
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class Torus(_SolidBase):
     """
@@ -100,7 +102,7 @@ class Torus(_SolidBase):
         return f"Torus : name={self.name} rmin={float(self.pRmin)} rmax={float(self.pRmax)} rtor={float(self.pRtor)} sphi={float(self.pSPhi)} dphi={float(self.pDPhi)}"
 
     def mesh(self):
-        _log.info("torus.antlr>")
+        _log.debug("torus.antlr>")
 
         from ...gdml import Units as _Units
 
@@ -113,7 +115,7 @@ class Torus(_SolidBase):
         pSPhi = self.evaluateParameter(self.pSPhi) * auval
         pDPhi = self.evaluateParameter(self.pDPhi) * auval
 
-        _log.info("torus.pycsgmesh>")
+        _log.debug("torus.pycsgmesh>")
         polygons = []
 
         nstack = self.nstack

--- a/src/pyg4ometry/geant4/solid/Trap.py
+++ b/src/pyg4ometry/geant4/solid/Trap.py
@@ -18,6 +18,8 @@ import logging as _log
 import numpy as _np
 import math as _math
 
+_log = _log.getLogger(__name__)
+
 
 class Trap(_SolidBase):
     """
@@ -123,7 +125,7 @@ class Trap(_SolidBase):
         return f"Trap : name={self.name} dz={self.pDz} theta={self.pTheta} dphi={self.pDPhi} dy1={self.pDy1} {self.pDx1} {self.pDx2} {self.pAlp1} {self.pDy2} {self.pDx3} {self.pDx4} {self.pAlp2}"
 
     def mesh(self):
-        _log.info("trap.antlr>")
+        _log.debug("trap.antlr>")
         from ...gdml import Units as _Units
 
         luval = _Units.unit(self.lunit)

--- a/src/pyg4ometry/geant4/solid/Trd.py
+++ b/src/pyg4ometry/geant4/solid/Trd.py
@@ -15,6 +15,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class Trd(_SolidBase):
     """
@@ -57,7 +59,7 @@ class Trd(_SolidBase):
             registry.addSolid(self)
 
     def mesh(self):
-        _log.info("trd.pycsgmesh> antlr")
+        _log.debug("trd.pycsgmesh> antlr")
         from ...gdml import Units as _Units
 
         luval = _Units.unit(self.lunit)
@@ -68,7 +70,7 @@ class Trd(_SolidBase):
         pY2 = self.evaluateParameter(self.pY2) * luval / 2.0
         pZ = self.evaluateParameter(self.pZ) * luval / 2.0
 
-        _log.info("trd.pycsgmesh> mesh")
+        _log.debug("trd.pycsgmesh> mesh")
         mesh = _CSG.fromPolygons(
             [
                 _Polygon(

--- a/src/pyg4ometry/geant4/solid/Tubs.py
+++ b/src/pyg4ometry/geant4/solid/Tubs.py
@@ -16,6 +16,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 import numpy as _np
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class Tubs(_SolidBase):
     """
@@ -85,7 +87,7 @@ class Tubs(_SolidBase):
         return f"Tubs : {self.name} rmin={float(self.pRMin)} rmax={float(self.pRMax)} dz={float(self.pDz)} sphi={float(self.pSPhi)} dphi={float(self.pDPhi)} lunit={self.lunit} aunit={self.aunit}"
 
     def mesh(self):
-        _log.info("tubs.pycsgmesh> antlr")
+        _log.debug("tubs.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -98,7 +100,7 @@ class Tubs(_SolidBase):
         pDz = self.evaluateParameter(self.pDz) * luval / 2
         pRMax = self.evaluateParameter(self.pRMax) * luval
 
-        _log.info("tubs.pycsgmesh> mesh")
+        _log.debug("tubs.pycsgmesh> mesh")
 
         polygons = []
 

--- a/src/pyg4ometry/geant4/solid/TwistedBox.py
+++ b/src/pyg4ometry/geant4/solid/TwistedBox.py
@@ -20,6 +20,8 @@ from .Layer import Layer as _Layer
 import numpy as _np
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class TwistedBox(_SolidBase, _TwistedSolid):
     """
@@ -113,7 +115,7 @@ class TwistedBox(_SolidBase, _TwistedSolid):
         return layers
 
     def mesh_old(self):
-        _log.info("twistedbox.pycsgmesh> antlr")
+        _log.debug("twistedbox.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -176,7 +178,7 @@ class TwistedBox(_SolidBase, _TwistedSolid):
         return [x, y]
 
     def mesh(self):
-        _log.info("twistedbox.pycsgmesh> antlr")
+        _log.debug("twistedbox.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -189,7 +191,7 @@ class TwistedBox(_SolidBase, _TwistedSolid):
         pDz = self.evaluateParameter(self.pDz) / 2.0 * luval
         refine = self.evaluateParameter(self.refine)
 
-        _log.info("twistedbox.mesh> mesh")
+        _log.debug("twistedbox.mesh> mesh")
 
         dTwist = twistedAngle / self.nstack
         dZ = 2 * pDz / self.nstack

--- a/src/pyg4ometry/geant4/solid/TwistedTrap.py
+++ b/src/pyg4ometry/geant4/solid/TwistedTrap.py
@@ -10,6 +10,8 @@ import numpy as _np
 
 # from memory_profiler import profile as _profile
 
+_log = _log.getLogger(__name__)
+
 
 class TwistedTrap(_SolidBase, _TwistedSolid):
     """
@@ -170,7 +172,7 @@ class TwistedTrap(_SolidBase, _TwistedSolid):
 
     # @_profile
     def mesh(self):
-        _log.info("twistedtrap.pycsgmesh> antlr")
+        _log.debug("twistedtrap.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -189,7 +191,7 @@ class TwistedTrap(_SolidBase, _TwistedSolid):
         pDx4 = self.evaluateParameter(self.pDx4) / 2.0 * luval
         pAlp = self.evaluateParameter(self.pAlp) * auval
 
-        _log.info("twistedtrap.pycsgmesh> mesh")
+        _log.debug("twistedtrap.pycsgmesh> mesh")
         # Bottom plane coordinates:
         pl1 = _TwoVector(-pDx1, -pDy1)
         pl2 = _TwoVector(pDx1, -pDy1)

--- a/src/pyg4ometry/geant4/solid/TwistedTrd.py
+++ b/src/pyg4ometry/geant4/solid/TwistedTrd.py
@@ -8,6 +8,8 @@ from .TwistedSolid import TwistedSolid as _TwistedSolid
 import numpy as _np
 import logging as _log
 
+_log = _log.getLogger(__name__)
+
 
 class TwistedTrd(_SolidBase, _TwistedSolid):
     """
@@ -115,7 +117,7 @@ class TwistedTrd(_SolidBase, _TwistedSolid):
         return layers
 
     def mesh(self):
-        _log.info("twistedtrd.pycsgmesh> antlr")
+        _log.debug("twistedtrd.pycsgmesh> antlr")
 
         from ...gdml import Units as _Units
 
@@ -129,7 +131,7 @@ class TwistedTrd(_SolidBase, _TwistedSolid):
         pDy2 = self.evaluateParameter(self.pDy2) / 2.0 * luval
         pDz = self.evaluateParameter(self.pDz) / 2.0 * luval
 
-        _log.info("twistedtrd.mesh> mesh")
+        _log.debug("twistedtrd.mesh> mesh")
         pl1 = _TwoVector(-pDx1, -pDy1)  # , pDz]
         pl2 = _TwoVector(pDx1, -pDy1)  # pDz]
         pl3 = _TwoVector(pDx1, pDy1)  # pDz]

--- a/src/pyg4ometry/geant4/solid/TwistedTubs.py
+++ b/src/pyg4ometry/geant4/solid/TwistedTubs.py
@@ -17,6 +17,8 @@ import logging as _log
 
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class TwistedTubs(_SolidBase):
     """
@@ -113,7 +115,7 @@ class TwistedTubs(_SolidBase):
         return layers
 
     def mesh(self):
-        _log.info("polycone.antlr>")
+        _log.debug("polycone.antlr>")
         from ...gdml import Units as _Units
 
         luval = _Units.unit(self.lunit)
@@ -126,7 +128,7 @@ class TwistedTubs(_SolidBase):
         phi = self.evaluateParameter(self.phi) * auval
         twistedangle = self.evaluateParameter(self.twistedangle) * auval
 
-        _log.info("polycone.basicmesh>")
+        _log.debug("polycone.basicmesh>")
         polygons = []
 
         stacks = self.nstack

--- a/src/pyg4ometry/geant4/solid/Union.py
+++ b/src/pyg4ometry/geant4/solid/Union.py
@@ -2,8 +2,9 @@ from .SolidBase import SolidBase as _SolidBase
 from ... import exceptions
 from ...transformation import *
 
-import copy as _copy
 import logging as _log
+
+_log = _log.getLogger(__name__)
 
 
 class Union(_SolidBase):
@@ -51,7 +52,7 @@ class Union(_SolidBase):
         return f"Union {self.name} {self.obj1.name} {self.obj2.name}"
 
     def mesh(self):
-        _log.info("union.pycsgmesh>")
+        _log.debug("union.pycsgmesh>")
 
         # look up solids in registry
         from ... import geant4 as _g4
@@ -62,19 +63,19 @@ class Union(_SolidBase):
         # transformation
         rot = tbxyz2axisangle(self.tra2[0].eval())
         tlate = self.tra2[1].eval()
-        _log.info(f"Union.pycsgmesh> rot={rot!s} tlate={tlate!s}")
+        _log.debug(f"Union.pycsgmesh> rot={rot!s} tlate={tlate!s}")
 
         # get meshes
-        _log.info("union.mesh> mesh1")
+        _log.debug("union.mesh> mesh1")
         m1 = obj1.mesh()
-        _log.info("union.mesh> mesh2")
+        _log.debug("union.mesh> mesh2")
         m2 = obj2.mesh().clone()
 
         # apply transform to second mesh
         m2.rotate(rot[0], -rad2deg(rot[1]))
         m2.translate(tlate)
 
-        _log.info("union.pycsgmesh> union")
+        _log.debug("union.pycsgmesh> union")
         mesh = m1.union(m2)
 
         return mesh

--- a/src/pyg4ometry/usd/solid/SolidBase.py
+++ b/src/pyg4ometry/usd/solid/SolidBase.py
@@ -1,9 +1,17 @@
-from pxr import Usd, UsdGeom, Sdf, Gf
+try:
+    from pxr import Usd, Gf, Sdf
+    from pxr.UsdGeom import Mesh as UsdGeomMesh
+except ImportError:
+    UsdGeomMesh = object
 
 
-class SolidBase(UsdGeom.Mesh):
+class SolidBase(UsdGeomMesh):
 
     def __init__(self, stage, path):
+        if UsdGeomMesh is object:
+            msg = "Failed to import open usd"
+            raise RuntimeError(msg)
+
         super().__init__(stage.GetPrimAtPath(path))
 
     def CreateCustomStingAttribute(self, name, value=""):

--- a/src/pyg4ometry/utils.py
+++ b/src/pyg4ometry/utils.py
@@ -2,6 +2,9 @@ import pickle
 import time
 import numpy as np
 from copy import deepcopy
+import logging
+
+_log = logging.getLogger(__name__)
 
 
 def _write_pickle(obj, path):
@@ -78,14 +81,14 @@ class Samples:
             existing = _load_pickle(path)
 
             if verbose:
-                print(f"Appending samples to {path}")
-                print(self.n_samples_description())
+                _log.info(f"Appending samples to {path}")
+                _log.info(f"{self.n_samples_description()}")
             new = Samples.from_existing(existing, self)
 
             _write_pickle(new, path)
         except FileNotFoundError:
             if verbose:
-                print(f"Writing new samples to {path}")
+                _log.info(f"Writing new samples to {path}")
             self.write(path)
 
     def __getitem__(self, key):

--- a/src/pyg4ometry/visualisation/BlenderViewer.py
+++ b/src/pyg4ometry/visualisation/BlenderViewer.py
@@ -7,14 +7,16 @@ import random as _random
 
 try:
     import bpy as _bpy
-
-    print("Blender pyg4ometry imported")
 except ImportError:
-    pass
+    _bpy = None
 
 
 class BlenderViewer(_ViewerBase):
     def __init__(self):
+        if _bpy is None:
+            msg = "blender python library not imported"
+            raise RuntimeError(msg)
+
         super().__init__()
         self.instanceBlenderOptions = {}
 
@@ -25,8 +27,6 @@ class BlenderViewer(_ViewerBase):
     def createBlenderObjectsUnique(self):
 
         for motherKey in self.instancePlacements:
-            print(motherKey)
-            # print(self.instancePlacements[motherKey])
 
             placements = self.instancePlacements[motherKey]
 

--- a/src/pyg4ometry/visualisation/Mesh.py
+++ b/src/pyg4ometry/visualisation/Mesh.py
@@ -12,6 +12,8 @@ elif _config.meshing == _config.meshingType.cgal_sm:
 import logging as _log
 import numpy as _np
 
+_log = _log.getLogger(__name__)
+
 
 class OverlapType:
     protrusion = 1
@@ -71,7 +73,7 @@ def _getBoundingBox(aMesh, rotationMatrix=None, translation=None, nameForError="
     """
     vertices, _, _ = aMesh.toVerticesAndPolygons()
     if not vertices:
-        print("Warning> getBoundingBox null mesh error : ", nameForError)
+        _log.warning("getBoundingBox null mesh error : %s", nameForError)
         if _config.meshingNullException:
             raise exceptions.NullMeshError(nameForError)
         else:
@@ -88,7 +90,7 @@ def _getBoundingBox(aMesh, rotationMatrix=None, translation=None, nameForError="
     vMin = [min(vertices[..., 0]), min(vertices[..., 1]), min(vertices[..., 2])]
     vMax = [max(vertices[..., 0]), max(vertices[..., 1]), max(vertices[..., 2])]
 
-    _log.info("visualisation.Mesh.getBoundingBox> %s %s", vMin, vMax)
+    _log.debug("visualisation.Mesh.getBoundingBox> %s %s", vMin, vMax)
 
     return [vMin, vMax]
 
@@ -107,7 +109,7 @@ def _getBoundingBoxMesh(boundingBox):
     pY = dy / 2.0
     pZ = dz / 2.0
 
-    _log.info("box.pycsgmesh> getBoundingBoxMesh")
+    _log.debug("box.pycsgmesh> getBoundingBoxMesh")
 
     mesh = _CSG.cube(center=[x0, y0, z0], radius=[pX, pY, pZ])
     return mesh

--- a/src/pyg4ometry/visualisation/ViewerBase.py
+++ b/src/pyg4ometry/visualisation/ViewerBase.py
@@ -2,12 +2,15 @@ import base64 as _base64
 import copy as _copy
 import numpy as _np
 import random as _random
+import logging as _log
 from .. import pycgal as _pycgal
 from .. import transformation as _transformation
 from .VisualisationOptions import (
     VisualisationOptions as _VisOptions,
 )
 from .Mesh import OverlapType as _OverlapType
+
+_log = _log.getLogger(__name__)
 
 
 def _daughterSubtractedMesh(lv):
@@ -165,7 +168,7 @@ class ViewerBase:
             pass
 
         else:
-            print("Unknown logical volume type or null mesh")
+            _log.warning("Unknown logical volume type or null mesh")
 
         for pv in lv.daughterVolumes:
             vo = self.getVisOptions(pv)
@@ -226,11 +229,10 @@ class ViewerBase:
                     self.addInstance(pv_name, new_mtra, new_tra, pv_name)
                     self.addVisOptions(pv_name, vo2)
 
-    def addFlukaRegions(self, fluka_registry, max_region=1000000, debugIO=False):
+    def addFlukaRegions(self, fluka_registry, max_region=1000000):
         icount = 0
         for k in fluka_registry.regionDict:
-            if debugIO:
-                print("ViewerBase.addFlukaRegions>", k)
+            _log.debug("ViewerBase.addFlukaRegions> %s", k)
             m = fluka_registry.regionDict[k].mesh()
 
             if m is not None:
@@ -432,7 +434,7 @@ class ViewerBase:
                 VEC3,
             )
         except ImportError:
-            print("pygltflib needs to be installed for export : 'pip install pygltflib'")
+            _log.error("pygltflib needs to be installed for export : 'pip install pygltflib'")
             return
 
         materials = []
@@ -603,7 +605,7 @@ class ViewerBase:
             f.write(glb)
             f.close()
         else:
-            print("ViewerBase::exportGLTFScene> unknown gltf extension")
+            _log.error("ViewerBase::exportGLTFScene> unknown gltf extension")
 
     def exportGLTFAssets(self, gltfFileName="test.gltf"):
         """Export all the assets (meshes) without all the instances. The position of the asset is
@@ -658,7 +660,7 @@ class ViewerBase:
             mesh = self.localmeshes[localmeshkey]
 
             if _pycgal.CGAL.is_triangle_mesh(mesh.sm):
-                print(
+                print(  # noqa: T201
                     localmeshkey,
                     mesh,
                     mesh.polygonCount(),
@@ -667,7 +669,7 @@ class ViewerBase:
                     mesh.volume(),
                 )
             else:
-                print(localmeshkey)
+                print(localmeshkey)  # noqa: T201
 
     def __repr__(self):
         return "ViewerBase"

--- a/src/pyg4ometry/visualisation/VtkExporter.py
+++ b/src/pyg4ometry/visualisation/VtkExporter.py
@@ -8,6 +8,8 @@ from . import (
 )
 import logging as _logging
 
+_log = _logging.getLogger(__name__)
+
 _WITH_PARAVIEW = True
 try:
     import paraview.simple as paras
@@ -15,7 +17,7 @@ except (ImportError, ImportWarning):
     _WITH_PARAVIEW = False
     msg = "paraview is required for this module to have full functionalities.\n"
     msg += "Not all methods will be available."
-    _logging.log(20, msg)
+    _log.warning(msg)
 
 
 class VtkExporter:
@@ -81,7 +83,7 @@ class VtkExporter:
                 )
                 paras.Show(xml, MapScalars=0)
                 index += 1
-                print((index / len(self.elements)) * 100, " %")
+                _log.info("%.2f %%", (index / len(self.elements)) * 100)
 
             paras.Render()
 
@@ -195,7 +197,7 @@ class VtkExporter:
             writer = _vtk.vtkXMLMultiBlockDataWriter()
             writer.SetDataModeToAscii()
             writer.SetInputData(self.mbdico[element])
-            print(f"Trying to write file {element}.vtm")
+            _log.info(f"Trying to write file {element}.vtm")
             writer.SetFileName(f"{self.path}/{element}.vtm")
             writer.Write()
 
@@ -332,8 +334,8 @@ class VtkExporter:
         if namestrip in self.materialVisualisationOptions.keys():
             return self.materialVisualisationOptions[namestrip]
         else:
-            print(
-                f"Warning, missing {namestrip} in materialVisualisationOptions, replace by default color"
+            _log.warning(
+                f"missing {namestrip} in materialVisualisationOptions, replace by default color"
             )
             return self.materialVisualisationOptions["G4_C"]
 

--- a/src/pyg4ometry/visualisation/VtkExporter.py
+++ b/src/pyg4ometry/visualisation/VtkExporter.py
@@ -15,9 +15,6 @@ try:
     import paraview.simple as paras
 except (ImportError, ImportWarning):
     _WITH_PARAVIEW = False
-    msg = "paraview is required for this module to have full functionalities.\n"
-    msg += "Not all methods will be available."
-    _log.warning(msg)
 
 
 class VtkExporter:

--- a/src/pyg4ometry/visualisation/VtkViewer.py
+++ b/src/pyg4ometry/visualisation/VtkViewer.py
@@ -12,6 +12,8 @@ from . import Convert as _Convert
 import logging as _log
 import random as _random
 
+_log = _log.getLogger(__name__)
+
 
 class VtkViewer:
     """
@@ -480,7 +482,7 @@ class VtkViewer:
                     )
                     first = False
                 except _exceptions.NullMeshError:
-                    print(solid.name, "> null mesh... continuing")
+                    _log.debug(f"{solid.name} > null mesh... continuing")
 
             obj1 = solid.object1()
             obj2 = solid.object2()
@@ -562,7 +564,7 @@ class VtkViewer:
             pv_name = pv.name
 
             if pv.logicalVolume.type == "logical":
-                _log.info(
+                _log.debug(
                     f"VtkViewer.addLogicalVolume> Daughter {pv.name} {pv.logicalVolume.name} {pv.logicalVolume.solid.name} "
                 )
 
@@ -699,7 +701,7 @@ class VtkViewer:
         clippers=False,
     ):
         # VtkPolyData : check if mesh is in localmeshes dict
-        _log.info("VtkViewer.addLogicalVolume> vtkPD")
+        _log.debug("VtkViewer.addLogicalVolume> vtkPD")
 
         if solid_name in localmeshes:
             vtkPD = localmeshes[solid_name]
@@ -754,7 +756,7 @@ class VtkViewer:
             vtkPD = normal_generator.GetOutput()
 
         # Filter : check if filter is in the filters dict
-        _log.info("VtkViewer.addLogicalVolume> vtkFLT")
+        _log.debug("VtkViewer.addLogicalVolume> vtkFLT")
         filtername = solid_name + "_filter"
         if filtername in filters:
             vtkFLT = filters[filtername]
@@ -764,7 +766,7 @@ class VtkViewer:
             filters[filtername] = vtkFLT
 
         # Mapper
-        _log.info("VtkViewer.addLogicalVolume> vtkMAP")
+        _log.debug("VtkViewer.addLogicalVolume> vtkMAP")
         mappername = pv_name + "_mapper"
         vtkMAP = _vtk.vtkPolyDataMapper()
         vtkMAP.ScalarVisibilityOff()
@@ -1109,10 +1111,10 @@ class VtkViewer:
 
     def printViewParameters(self):
         activeCamera = self.ren.GetActiveCamera()
-        print("Window size     ", self.renWin.GetSize())
-        print("Focal point     ", activeCamera.GetFocalPoint())
-        print("Camera position ", activeCamera.GetPosition())
-        print("Focal distance  ", activeCamera.GetDistance())
+        print("Window size     ", self.renWin.GetSize())  # noqa: T201
+        print("Focal point     ", activeCamera.GetFocalPoint())  # noqa: T201
+        print("Camera position ", activeCamera.GetPosition())  # noqa: T201
+        print("Focal distance  ", activeCamera.GetDistance())  # noqa: T201
 
 
 class VtkViewerColoured(VtkViewer):
@@ -1216,7 +1218,7 @@ class MouseInteractorNamePhysicalVolume(_vtk.vtkInteractorStyleTrackballCamera):
                 pass
             else:
                 name = name[: name.find("_actor")]
-                print(f"{type(self.vtkviewer).__name__}> selected> {name}")
+                _log.debug(f"{type(self.vtkviewer).__name__}> selected> {name}")
 
 
 def axesFromExtents(extent):

--- a/src/pyg4ometry/visualisation/VtkViewerNew.py
+++ b/src/pyg4ometry/visualisation/VtkViewerNew.py
@@ -105,7 +105,8 @@ class VtkViewerNew(_ViewerBase):
 
     def addCutter(self, name, origin, normal):
         if self.bBuiltPipelines:
-            print("Need to add cutter before pipelines are built")
+            msg = "Need to add cutter before pipelines are built"
+            raise RuntimeError(msg)
 
         self.cutterOrigins[name] = origin
         self.cutterNormals[name] = normal
@@ -179,7 +180,8 @@ class VtkViewerNew(_ViewerBase):
 
     def addClipper(self, origin, normal, bClipperCutter=False, bClipperCloseCuts=True):
         if self.bBuiltPipelines:
-            print("Need to add clipper before pipelines are built")
+            msg = "Need to add clipper before pipelines are built"
+            raise RuntimeError(msg)
 
         self.bClipper = True
         self.clipperOrigin = origin
@@ -205,16 +207,14 @@ class VtkViewerNew(_ViewerBase):
 
     def addClipperWidget(self):
         if not self.bBuiltPipelines:
-            print(
+            msg = (
                 "Need to build pipelines before adding clipper widget e.g. v.bulidPipelinesAppend()"
             )
-            return
+            raise RuntimeError(msg)
 
         if len(self.clippers) == 0:
-            print(
-                "Need to add a clipping plane adding clipper widget e.g. v.addClipper([0, 0, 0], [0, 0, 1], True"
-            )
-            return
+            msg = "Need to add a clipping plane adding clipper widget e.g. v.addClipper([0, 0, 0], [0, 0, 1], True"
+            raise RuntimeError(msg)
 
         plaRep = _vtk.vtkImplicitPlaneRepresentation()
         # plaRep.SetPlaceFactor(1.25)
@@ -483,16 +483,16 @@ class VtkViewerNew(_ViewerBase):
 
     def render(self):
         if not self.bBuiltPipelines:
-            print("Pipelines have not been built")
-            return
+            msg = "Pipelines have not been built"
+            raise RuntimeError(msg)
 
         # Render
         self.renWin.Render()
 
     def view(self, interactive=True, resetCamera=False):
         if not self.bBuiltPipelines:
-            print("Pipelines have not been built")
-            return
+            msg = "Pipelines have not been built"
+            raise RuntimeError(msg)
 
         # enable user interface interactor
         self.iren.Initialize()
@@ -649,7 +649,7 @@ class MouseInteractorNamePhysicalVolume(_vtk.vtkInteractorStyleTrackballCamera):
             self.ren.RemoveActor(self.highLightActor)
 
         clickPos = self.GetInteractor().GetEventPosition()
-        print("clickPos> ", clickPos)
+        # print("clickPos> ", clickPos)
 
         picker = _vtk.vtkPropPicker()
         picker.Pick(clickPos[0], clickPos[1], 0, self.ren)
@@ -657,7 +657,7 @@ class MouseInteractorNamePhysicalVolume(_vtk.vtkInteractorStyleTrackballCamera):
 
         pointPicker = _vtk.vtkPointPicker()
         pointPicker.Pick(clickPos[0], clickPos[1], 0, self.ren)
-        print("pointId>", pointPicker.GetPointId())
+        # print("pointId>", pointPicker.GetPointId())
 
         cellPicker = _vtk.vtkCellPicker()
         cellPicker.SetPickClippingPlanes(False)
@@ -684,10 +684,10 @@ class MouseInteractorNamePhysicalVolume(_vtk.vtkInteractorStyleTrackballCamera):
                 .GetInputAlgorithm()
             )
 
-        print(self.inalgo.GetClassName(), appPolyData.GetClassName())
+        # print(self.inalgo.GetClassName(), appPolyData.GetClassName())
 
         point = self.inalgo.GetOutput().GetPoint(cellPicker.GetPointId())
-        print("pointPos>", point)
+        # print("pointPos>", point)
 
         # loop over appendPolyData and find closest
         dmin = 1e99
@@ -717,7 +717,7 @@ class MouseInteractorNamePhysicalVolume(_vtk.vtkInteractorStyleTrackballCamera):
 
         tba = _transformation.matrix2tbxyz(mtra)
 
-        print("minimum pd>", di, dmin, lvName, pvName, tba, tra, localExtent, globalExtent)
+        # print("minimum pd>", di, dmin, lvName, pvName, tba, tra, localExtent, globalExtent)
 
         if self.highLightActor:
             self.ren.RemoveActor(self.highLightActor)

--- a/tests/fluka/T201_RPP_coplanar.py
+++ b/tests/fluka/T201_RPP_coplanar.py
@@ -36,7 +36,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T201_RPP_coplanar.inp"
 

--- a/tests/fluka/T202_BOX_coplanar.py
+++ b/tests/fluka/T202_BOX_coplanar.py
@@ -38,7 +38,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wv = greg.getWorldVolume()
-    wv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T202_BOX_coplanar.inp"
 

--- a/tests/fluka/T203_SPH_coplanar.py
+++ b/tests/fluka/T203_SPH_coplanar.py
@@ -36,7 +36,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T203_SPH_coplanar.inp"
 

--- a/tests/fluka/T204_RCC_coplanar.py
+++ b/tests/fluka/T204_RCC_coplanar.py
@@ -38,7 +38,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wv = greg.getWorldVolume()
-    wv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T204_RCC_coplanar.inp"
 

--- a/tests/fluka/T205_REC_coplanar.py
+++ b/tests/fluka/T205_REC_coplanar.py
@@ -39,7 +39,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wv = greg.getWorldVolume()
-    wv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T205_REC_coplanar.inp"
 

--- a/tests/fluka/T206_TRC_coplanar.py
+++ b/tests/fluka/T206_TRC_coplanar.py
@@ -42,7 +42,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wv = greg.getWorldVolume()
-    wv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T206_TRC_coplanar.inp"
 

--- a/tests/fluka/T207_ELL_coplanar.py
+++ b/tests/fluka/T207_ELL_coplanar.py
@@ -46,7 +46,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
 
     greg = convert.fluka2Geant4(freg)
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T207_ELL_coplanar.inp"
 

--- a/tests/fluka/T208_RAW_coplanar.py
+++ b/tests/fluka/T208_RAW_coplanar.py
@@ -55,7 +55,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T208_RAW_coplanar.inp"
 

--- a/tests/fluka/T208_WED_coplanar.py
+++ b/tests/fluka/T208_WED_coplanar.py
@@ -55,7 +55,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T208_WED_coplanar.inp"
 

--- a/tests/fluka/T209_ARB_coplanar.py
+++ b/tests/fluka/T209_ARB_coplanar.py
@@ -49,7 +49,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
 
     greg = convert.fluka2Geant4(freg)
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T209_ARB_coplanar.inp"
 

--- a/tests/fluka/T210_PLA_coplanar.py
+++ b/tests/fluka/T210_PLA_coplanar.py
@@ -63,7 +63,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T210_PLA_coplanar.inp"
 

--- a/tests/fluka/T210_XYP_coplanar.py
+++ b/tests/fluka/T210_XYP_coplanar.py
@@ -64,7 +64,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
 
     wlv = greg.getWorldVolume()
 
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T210_XYP_coplanar.inp"
 

--- a/tests/fluka/T210_XZP_coplanar.py
+++ b/tests/fluka/T210_XZP_coplanar.py
@@ -64,7 +64,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
 
     wlv = greg.getWorldVolume()
 
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T210_ZXP_coplanar.inp"
 

--- a/tests/fluka/T210_YZP_coplanar.py
+++ b/tests/fluka/T210_YZP_coplanar.py
@@ -64,7 +64,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
 
     wlv = greg.getWorldVolume()
 
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T210_YZP_coplanar.inp"
 

--- a/tests/fluka/T212_XCC_coplanar.py
+++ b/tests/fluka/T212_XCC_coplanar.py
@@ -47,7 +47,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T212_XCC_coplanar.inp"
 

--- a/tests/fluka/T212_YCC_coplanar.py
+++ b/tests/fluka/T212_YCC_coplanar.py
@@ -47,7 +47,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T212_YCC_coplanar.inp"
 

--- a/tests/fluka/T212_ZCC_coplanar.py
+++ b/tests/fluka/T212_ZCC_coplanar.py
@@ -47,7 +47,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True, splitDisjointUnions=False)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T212_ZCC_coplanar.inp"
 

--- a/tests/fluka/T213_XEC_coplanar.py
+++ b/tests/fluka/T213_XEC_coplanar.py
@@ -50,7 +50,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T213_XEC_coplanar.inp"
 

--- a/tests/fluka/T213_YEC_coplanar.py
+++ b/tests/fluka/T213_YEC_coplanar.py
@@ -50,7 +50,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T213_YEC_coplanar.inp"
 

--- a/tests/fluka/T213_ZEC_coplanar.py
+++ b/tests/fluka/T213_ZEC_coplanar.py
@@ -50,7 +50,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     greg = convert.fluka2Geant4(freg, withLengthSafety=True)
 
     wlv = greg.getWorldVolume()
-    wlv.checkOverlaps(recursive=False, coplanar=True, debugIO=False)
+    wlv.checkOverlaps(recursive=False, coplanar=True)
 
     outputFile = outputPath / "T213_ZEC_coplanar.inp"
 

--- a/tests/geant4/T102_overlap_none.py
+++ b/tests/geant4/T102_overlap_none.py
@@ -44,7 +44,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     rp = _g4.PhysicalVolume([0, 0, 0], [0, 0, 0], rl, "r_pv1", wl, reg)
 
     # check for overlaps
-    wl.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    wl.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(wl.name)

--- a/tests/geant4/T103_overlap_copl.py
+++ b/tests/geant4/T103_overlap_copl.py
@@ -85,7 +85,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     bp14 = _g4.PhysicalVolume([0, 0, 0], [+1.5 * wx / 2 - bx / 4, 0, 0], bl, "b_pv14", wl, reg)
 
     # check for overlaps
-    wl.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    wl.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(wl.name)

--- a/tests/geant4/T103_overlap_copl_simple.py
+++ b/tests/geant4/T103_overlap_copl_simple.py
@@ -35,7 +35,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     bp2 = _g4.PhysicalVolume([0, 0.3, 0], [0, bx, 0], bl, "b_pv2", wl, reg)
 
     # check for overlaps
-    wl.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    wl.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(wl.name)

--- a/tests/geant4/T104_overlap_volu.py
+++ b/tests/geant4/T104_overlap_volu.py
@@ -50,7 +50,7 @@ def Test(vis=False, interactive=False, outputPath=None, refFilePath=None):
     rp1 = _g4.PhysicalVolume([0, 0, 0], [3 * bx, 0, 0], rl, "r_pv1", wl, reg)
     rp2 = _g4.PhysicalVolume([0, 0, 0], [-3 * bx, 0, 0], rl, "r_pv2", wl, reg, True, [-1, 1, 1])
     # check overlaps
-    wl.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    wl.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(wl.name)

--- a/tests/geant4/T300_overlap_assembly_regular_lv.py
+++ b/tests/geant4/T300_overlap_assembly_regular_lv.py
@@ -21,7 +21,7 @@ def Test(vis=False, interactive=False):
     boxPV1 = _g4.PhysicalVolume([0, 0, 0], [0, 0, 20], aBoxLV, "abox_pv1", worldLV, reg)
 
     # check for overlaps
-    worldLV.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    worldLV.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(worldLV)

--- a/tests/geant4/T301_overlap_assembly_none.py
+++ b/tests/geant4/T301_overlap_assembly_none.py
@@ -19,7 +19,7 @@ def Test(vis=False, interactive=False):
     asPV2 = _g4.PhysicalVolume([0, 0, 0], [50, 0, 0], assembly, "part_pv2", worldLV, reg)
 
     # check for overlaps
-    worldLV.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    worldLV.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(worldLV)

--- a/tests/geant4/T302_overlap_assembly_coplanar.py
+++ b/tests/geant4/T302_overlap_assembly_coplanar.py
@@ -19,7 +19,7 @@ def Test(vis=False, interactive=False):
     asPV2 = _g4.PhysicalVolume([0, 0, 0], [50, 0, 0], assembly, "part_pv2", worldLV, reg)
 
     # check for overlaps
-    worldLV.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    worldLV.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(worldLV)

--- a/tests/geant4/T303_overlap_assembly_daughter_collision.py
+++ b/tests/geant4/T303_overlap_assembly_daughter_collision.py
@@ -19,7 +19,7 @@ def Test(vis=False, interactive=False):
     asPV2 = _g4.PhysicalVolume([0, 0, 0], [50, 0, 0], assembly, "part_pv2", worldLV, reg)
 
     # check for overlaps
-    worldLV.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    worldLV.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(worldLV)

--- a/tests/geant4/T304_overlap_assembly_volumetric.py
+++ b/tests/geant4/T304_overlap_assembly_volumetric.py
@@ -25,7 +25,7 @@ def Test(vis=False, interactive=False):
     )
 
     # check for overlaps
-    worldLV.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    worldLV.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(worldLV)

--- a/tests/geant4/T305_overlap_assembly_nested.py
+++ b/tests/geant4/T305_overlap_assembly_nested.py
@@ -32,7 +32,7 @@ def Test(vis=False, interactive=False):
     )
 
     # check for overlaps
-    worldLV.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    worldLV.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(worldLV)

--- a/tests/geant4/test_overlap_copl.py
+++ b/tests/geant4/test_overlap_copl.py
@@ -82,7 +82,7 @@ def overlap_copl(vis=False, interactive=False):
     bp14 = _g4.PhysicalVolume([0, 0, 0], [+1.5 * wx / 2 - bx / 4, 0, 0], bl, "b_pv14", wl, reg)
 
     # check for overlaps
-    wl.checkOverlaps(recursive=True, coplanar=True, debugIO=False)
+    wl.checkOverlaps(recursive=True, coplanar=True)
 
     # set world volume
     reg.setWorld(wl.name)


### PR DESCRIPTION
* add inline `# noqa: T201` comments for intended `print()` usage
* use properly module-scoped logger naming to avoid spamming the root logger
* replace all other `print()` statements either with logging statements, or remove them
* lower the log level from INFO to DEBUG in a lot of cases

there are some parts that have not been converted. Those are listed in `pyproject.toml`:
```
"src/pyg4ometry/gui/**" = ["T201"]
"src/pyg4ometry/{fluka,convert}/**" = ["T201"]
"src/pyg4ometry/{io,analysis,features}/**" = ["T201"]
"src/pyg4ometry/{freecad,pycgal,pyoce}/**" = ["T201"]
"src/pyg4ometry/visualisation/{UsdViewer,ViewerHierarchyBase}.py" = ["T201"]
```

Those are either "unfinished"(?) parts, or I do not know enough about that code.