### PR TITLE
Fix colour vis for assemblies / replicas / divisions

### DIFF
--- a/src/pyg4ometry/gdml/Writer.py
+++ b/src/pyg4ometry/gdml/Writer.py
@@ -392,8 +392,8 @@ option, physicsList="em";
         if self._writeColour and lv.visOptions:
             cAux = VisOptionsToAuxiliary(lv.visOptions)
             aux.append(cAux)
-        for aux in lv.auxiliary:
-            self.writeAuxiliary(aux, parent=we)
+        for _aux in aux:
+            self.writeAuxiliary(_aux, parent=we)
 
         for dv in lv.daughterVolumes:
             if dv.type == "placement":

--- a/src/pyg4ometry/geant4/LogicalVolume.py
+++ b/src/pyg4ometry/geant4/LogicalVolume.py
@@ -155,7 +155,7 @@ class LogicalVolume:
         """
         if type(colour) == str:
             hex = colour.lstrip("#")
-            colour = list(int(hex[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
+            colour = [int(hex[i : i + 2], 16) / 255.0 for i in (0, 2, 4)]
         if not self.visOptions:
             self.visOptions = _VisOptions(colour=colour, alpha=alpha)
         else:

--- a/src/pyg4ometry/geant4/LogicalVolume.py
+++ b/src/pyg4ometry/geant4/LogicalVolume.py
@@ -144,6 +144,24 @@ class LogicalVolume:
         self.daughterVolumes.append(physicalVolume)
         self._daughterVolumesDict[physicalVolume.name] = physicalVolume
 
+    def setColour(self, colour, alpha=1.0):
+        """
+        Set the visualisation colour of a logical volume. Takes either #hexrgb or [r,g,b] (normalised)
+
+        :param colour: hexrgb code or list of normalised rgb components
+        :type colour: str, [float, float, float]
+        :param alpha: optional transparency from 0 (invisible) to 1 (visible)
+        :type alpha: float
+        """
+        if type(colour) == str:
+            hex = colour.lstrip('#')
+            colour = list(int(hex[i:i + 2], 16)/255.0 for i in (0, 2, 4))
+        if not self.visOptions:
+            self.visOptions = _VisOptions(colour=colour, alpha=alpha)
+        else:
+            self.visOptions.colour = colour
+            self.visOptions.alpha = alpha
+
     def addBDSIMObject(self, bdsimobject):
         self.bdsimObjects.append(bdsimobject)
 

--- a/src/pyg4ometry/geant4/LogicalVolume.py
+++ b/src/pyg4ometry/geant4/LogicalVolume.py
@@ -154,8 +154,8 @@ class LogicalVolume:
         :type alpha: float
         """
         if type(colour) == str:
-            hex = colour.lstrip('#')
-            colour = list(int(hex[i:i + 2], 16)/255.0 for i in (0, 2, 4))
+            hex = colour.lstrip("#")
+            colour = list(int(hex[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
         if not self.visOptions:
             self.visOptions = _VisOptions(colour=colour, alpha=alpha)
         else:

--- a/src/pyg4ometry/visualisation/VisualisationOptions.py
+++ b/src/pyg4ometry/visualisation/VisualisationOptions.py
@@ -66,7 +66,7 @@ class VisualisationOptions:
 
     def getBDSIMVRGBA(self):
         c = self.colour
-        return f"{int(self.visible)} {c[0]} {c[1]} {c[2]} {self.alpha}"
+        return f"{int(self.visible)} {c[0]:.4f} {c[1]:.4f} {c[2]:.4f} {self.alpha}"
 
     def getColour(self):
         """

--- a/src/pyg4ometry/visualisation/VtkViewer.py
+++ b/src/pyg4ometry/visualisation/VtkViewer.py
@@ -1091,7 +1091,7 @@ class VtkViewer:
 
         # a dict evaluates to True if not empty
         materialVis = None
-        if self.materialVisOptions:
+        if self.materialVisOptions and pv.logicalVolume.type == "logical":
             materialName = pv.logicalVolume.material.name
             # if 0x is in name, strip the appended pointer (common in exported GDML)
             if "0x" in materialName:

--- a/tests/visualisation/test_Visualisation.py
+++ b/tests/visualisation/test_Visualisation.py
@@ -108,11 +108,13 @@ def test_VtkViewerColoured(testdata, tmptestdir):
 def test_VtkViewerColoured_setColour(testdata, tmptestdir):
     r = _pyg4.gdml.Reader(testdata["gdml/CompoundExamples/bdsim/vkickers.gdml"])
     reg = r.getRegistry()
-    coil = reg.logicalVolumeDict['m3_coil_lv0x7fc499f68a00']
+    coil = reg.logicalVolumeDict["m3_coil_lv0x7fc499f68a00"]
     coil.setColour("f5ee2f")  # yellow
-    yoke = reg.logicalVolumeDict['m6_yoke_lv0x7fc49c0168c0']
-    yoke.setColour([0.9607843137254902, 0.9333333333333333, 0.1843137254901961])  # yellow but rgb normalised
-    
+    yoke = reg.logicalVolumeDict["m6_yoke_lv0x7fc49c0168c0"]
+    yoke.setColour(
+        [0.9607843137254902, 0.9333333333333333, 0.1843137254901961]
+    )  # yellow but rgb normalised
+
     v = _pyg4.visualisation.VtkViewerColoured()
     v.addLogicalVolume(r.getRegistry().getWorldVolume())
 

--- a/tests/visualisation/test_Visualisation.py
+++ b/tests/visualisation/test_Visualisation.py
@@ -105,6 +105,18 @@ def test_VtkViewerColoured(testdata, tmptestdir):
     v.addAxes(20, (0, 0, 0))
 
 
+def test_VtkViewerColoured_setColour(testdata, tmptestdir):
+    r = _pyg4.gdml.Reader(testdata["gdml/CompoundExamples/bdsim/vkickers.gdml"])
+    reg = r.getRegistry()
+    coil = reg.logicalVolumeDict['m3_coil_lv0x7fc499f68a00']
+    coil.setColour("f5ee2f")  # yellow
+    yoke = reg.logicalVolumeDict['m6_yoke_lv0x7fc49c0168c0']
+    yoke.setColour([0.9607843137254902, 0.9333333333333333, 0.1843137254901961])  # yellow but rgb normalised
+    
+    v = _pyg4.visualisation.VtkViewerColoured()
+    v.addLogicalVolume(r.getRegistry().getWorldVolume())
+
+
 def test_VtkViewerColouredMaterial(testdata, tmptestdir):
     r = _pyg4.gdml.Reader(testdata["gdml/T104_overlap_volu.gdml"])
     l = r.getRegistry().getWorldVolume()


### PR DESCRIPTION
The recent changes I introduced for allowing control over colour for individual LVs didn't work for assemblies, replicas and division volumes and would raise an exception and block visualisation. Fixed.

Also, added convenience function to allow easy setting of colour by list of rgb or by hex code (common from online tables for html).

Fix writing of auxiliary tags in gdml if they were user-set and didn't come from a previous load.