### PR TITLE
Fix fluka reading memory

### DIFF
--- a/src/pyg4ometry/fluka/card.py
+++ b/src/pyg4ometry/fluka/card.py
@@ -64,10 +64,9 @@ class Card:
 
     @classmethod
     def fromFree(cls, line):
-        card_bits = freeFormatStringSplit(line)
-        while len(card_bits) != 8:
-            card_bits.append(None)
-        return cls(*card_bits)
+        cards = freeFormatStringSplit(line)
+        cards = (cards + 8 * [None])[:8]  # ensure at least 8
+        return cls(*cards)
 
     @classmethod
     def fromFixed(cls, line):

--- a/src/pyg4ometry/fluka/card.py
+++ b/src/pyg4ometry/fluka/card.py
@@ -115,12 +115,3 @@ def freeFormatStringSplit(string):
         components.extend(chunk.split())
 
     return components
-
-
-def main(filein):
-    c = Card(TEST_STRING)
-    m = rotdefini_to_matrix(c)
-
-
-if __name__ == "__main__":
-    main("asdasd")  # sys.argv[1])

--- a/src/pyg4ometry/fluka/card.py
+++ b/src/pyg4ometry/fluka/card.py
@@ -102,6 +102,6 @@ def freeFormatStringSplit(string):
     First, replace all with commas then split on those.
     """
     ensure_commas = re.sub(r" *[,:;\\] *", ",", string.strip())
-    ensure_commas = re.sub(r" +", ",", ensure_commas).split(',')
+    ensure_commas = re.sub(r" +", ",", ensure_commas).split(",")
     components = [s if len(s) > 0 else None for s in ensure_commas]
     return components

--- a/src/pyg4ometry/fluka/card.py
+++ b/src/pyg4ometry/fluka/card.py
@@ -97,21 +97,12 @@ def _attempt_float_coercion(string):
 
 
 def freeFormatStringSplit(string):
-    """Method to split a string in FLUKA FREE format into its components."""
-    # Split the string along non-black separators [,;:/\]
-    partial_split = re.split(";|,|\\/|:|\\\\|\n", rf"{string}")
-
-    # Populate zeros between consequtive non-blank separators as per
-    # the FLUKA manual.
-    is_blank = lambda s: not set(s) or set(s) == {" "}
-    noblanks_split = [chunk if not is_blank(chunk) else None for chunk in partial_split]
-
-    # Strip whitespace
-    components = []
-    for chunk in noblanks_split:
-        if chunk is None:
-            components.append(None)
-            continue
-        components.extend(chunk.split())
-
+    """
+    Method to split a string in FLUKA FREE format into its components.
+    The delimiter can be 1 or more spaces but also single ',' ':' ';' '\'.
+    First, replace all with commas then split on those.
+    """
+    ensure_commas = re.sub(r" *[,:;\\] *", ",", string.strip())
+    ensure_commas = re.sub(r" +", ",", ensure_commas).split(',')
+    components = [s if len(s) > 0 else None for s in ensure_commas]
     return components

--- a/src/pyg4ometry/fluka/reader.py
+++ b/src/pyg4ometry/fluka/reader.py
@@ -790,18 +790,21 @@ class SensitiveErrorListener(ErrorListener.ErrorListener):
 
     def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
         msgf = f"At ({line}, {column}), Error: {msg}.  Warning: The provided line number is in this section."
-        msg2a = recognizer._input.strdata[e.startIndex - 50 : e.startIndex]
-        msg2b = recognizer._input.strdata[e.startIndex : e.startIndex + 1]
-        msg2c = recognizer._input.strdata[e.startIndex + 1 : e.startIndex + 50]
-        msgf += (
-            '\nSurrounding text +- 50 characaters\n"'
-            + msg2a
-            + "\033[1m"
-            + msg2b
-            + "\033[0m"
-            + msg2c
-            + '"'
-        )
+        try:
+            msg2a = recognizer._input.strdata[e.startIndex - 50 : e.startIndex]
+            msg2b = recognizer._input.strdata[e.startIndex : e.startIndex + 1]
+            msg2c = recognizer._input.strdata[e.startIndex + 1 : e.startIndex + 50]
+            msgf += (
+                '\nSurrounding text +- 50 characaters\n"'
+                + msg2a
+                + "\033[1m"
+                + msg2b
+                + "\033[0m"
+                + msg2c
+                + '"'
+            )
+        except:
+            pass
         raise antlr4.error.Errors.ParseCancellationException(msgf)
 
 


### PR DESCRIPTION
Fix huge memory usage for reading fluka input files - really up to 50Gb or more for fairly big (but still ~200kb) input file.

Better use of regex and better algorithm to handle to overly numerous possible delimiters in fluka input.