### PR TITLE
pass args and kwargs from VtkViewerColouredNew

### DIFF
--- a/src/pyg4ometry/visualisation/VtkViewerNew.py
+++ b/src/pyg4ometry/visualisation/VtkViewerNew.py
@@ -558,11 +558,10 @@ class VtkViewerNew(_ViewerBase):
 
 class VtkViewerColouredNew(VtkViewerNew):
     """
-    Visualiser that extends VtkViewer. Uses "flat" interpolation and introduces control over colours.
+    Visualiser that extends VtkViewer. Introduces control over colours.
 
     :Keyword Arguments:
         * **materialVisOptions**: {"materialName": :class:`VisualisationOptions` or list or tuple, ...}
-        * **interpolation** (str): see :class:`VtkViewer`
         * **defaultColour** (str): "random" or [r,g,b]
 
     :Examples:
@@ -585,8 +584,7 @@ class VtkViewerColouredNew(VtkViewerNew):
     """
 
     def __init__(self, *args, defaultColour=None, materialVisOptions=None, **kwargs):
-        kwargs["interpolation"] = kwargs.get("interpolation", "flat")
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         self._defaultVis = _VisOptions()
         self._defaultVis.randomColour = defaultColour == "random"


### PR DESCRIPTION
also removes some dead code around the `interpolation` paramameter which was never actually used in the new viewer implementation.