### PR TITLE
Fix problem with assembly volumes in new viewer

### DIFF
--- a/src/pyg4ometry/visualisation/ViewerBase.py
+++ b/src/pyg4ometry/visualisation/ViewerBase.py
@@ -85,7 +85,9 @@ class ViewerBase:
         """
         Return a set of vis options according to the precedence of pv, lv, material, default.
         """
-        materialVis = self._getMaterialVis(pv.logicalVolume.material.name)
+        materialVis = None
+        if pv.logicalVolume.type == "logical" :
+            materialVis = self._getMaterialVis(pv.logicalVolume.material.name)
         # take the first non-None set of visOptions
         orderOfPrecedence = [
             pv.visOptions,


### PR DESCRIPTION
When trying to display geometry involving assembly volumes in the new viewer in v1.3.5 I get a crash:

```
Traceback (most recent call last):
  File "/Users/tlatham/cernbox/Development-Mac/LHCb/GeometryValidation/pyg4ometry-scripts/showGeomColoured.py", line 44, in <module>
    v.addLogicalVolume(l)
  File "/Users/tlatham/miniforge3/envs/pyg4-test/lib/python3.12/site-packages/pyg4ometry/visualisation/ViewerBase.py", line 189, in addLogicalVolume
    self.addLogicalVolume(
  File "/Users/tlatham/miniforge3/envs/pyg4-test/lib/python3.12/site-packages/pyg4ometry/visualisation/ViewerBase.py", line 189, in addLogicalVolume
    self.addLogicalVolume(
  File "/Users/tlatham/miniforge3/envs/pyg4-test/lib/python3.12/site-packages/pyg4ometry/visualisation/ViewerBase.py", line 174, in addLogicalVolume
    vo = self.getVisOptions(pv)
         ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tlatham/miniforge3/envs/pyg4-test/lib/python3.12/site-packages/pyg4ometry/visualisation/ViewerBase.py", line 88, in getVisOptions
    materialVis = self._getMaterialVis(pv.logicalVolume.material.name)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'AssemblyVolume' object has no attribute 'material'
```

This is solved by applying the change in this PR.