### PR TITLE
remove new accidental pytest dependency

### DIFF
--- a/src/pyg4ometry/features/algos.py
+++ b/src/pyg4ometry/features/algos.py
@@ -4,7 +4,6 @@ import scipy.linalg as _la
 import matplotlib.pyplot as _plt
 import random as _rand
 from scipy.spatial.transform import Rotation as _Rotation
-import pytest
 
 
 class Line:
@@ -805,10 +804,13 @@ class FeatureData:
             )
 
 
-@pytest.mark.parametrize(
-    ("featureIndexList", "planeQuality", "circumference", "bPlotRadii"), [([], 0.1, 300, False)]
-)
-def test(fileName, featureIndexList, planeQuality, circumference, bPlotRadii):
+def test(
+    fileName,
+    featureIndexList=[],  # noqa: PT028
+    planeQuality=0.1,  # noqa: PT028
+    circumference=300,  # noqa: PT028
+    bPlotRadii=False,  # noqa: PT028
+):
     p = vtkLoadStl(fileName)
     e = vtkPolydataToConnectedEdges(p, 89)
     i = vtkPolydataEdgeInformation(e)


### PR DESCRIPTION
this never was a pytest function. The new formatting looks bad, unfortunetly there is no sane way to keep the parameter list looking nicely.

This should be merged ASAP as this breaks any usage of pyg4ometry when pytest is not installed