### PR TITLE
docs: unpin sphinx-autoapi to restore API reference

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,4 +13,4 @@ build:
     python: "3.10"
   jobs:
     post_install:
-      - pip install --upgrade --upgrade-strategy only-if-needed furo "sphinx>=7.2.2" "sphinx-autoapi<3.4.0" sphinx-copybutton sphinx-inline-tabs
+      - pip install --upgrade --upgrade-strategy only-if-needed furo "sphinx>=7.4.0" sphinx-autoapi sphinx-copybutton sphinx-inline-tabs


### PR DESCRIPTION
## Problem

The published docs lost their entire Python API reference: `objects.inv` currently has **zero `py:` entries** (only `std:doc`/`std:label`), so any intersphinx cross-reference into pyg4ometry from downstream projects fails to resolve. No code changed; this regressed silently.

## Root cause

`.readthedocs.yaml` pins `sphinx-autoapi<3.4.0`, which installs autoapi **3.3.x**. autoapi 3.3.x declares only a lower bound on astroid (`astroid>=3.0.0a1`, no upper cap), so when **astroid 4.0** was released it got pulled into the RTD env. autoapi 3.3.x cannot parse astroid 4's AST, so the build logs `WARNING: No modules were rendered` and emits no API pages or inventory objects.

Reproduced exactly (sphinx 8.2.3 + autoapi 3.3.3 + astroid 4.1.2): `{std:label: 16, std:doc: 18}`, 0 `py:` entries.

## Fix

Drop the `<3.4.0` upper pin so a current autoapi (3.8.0, which supports astroid 4) is installed, and raise the Sphinx floor to `>=7.4.0` (required by autoapi 3.8.0).

Verified locally with the unpinned toolchain: API inventory restored from **0 → ~7,700 `py:` entries**, including `pyg4ometry.geant4.Registry` and `pyg4ometry.gdml.Defines.Position`.

## Notes

- Longer term, consider moving the doc toolchain into a pinned dependency group instead of an ad-hoc `post_install` pip line, so an unbounded transitive dep can't drift in again.
- Unrelated: `src/pyg4ometry/bdsim/scoring.py` logs `Unable to read file` during the autoapi pass; worth a separate look.